### PR TITLE
Make secure mode more robust

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
 	"id": "notetweet",
 	"name": "NoteTweet🐦",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"minAppVersion": "0.9.12",
 	"description": "This plugin allows you to post tweets directly from Obsidian.",
-	"author": "Christian",
+	"author": "Christian B. B. Houmann",
 	"authorUrl": "https://bagerbach.com/",
 	"isDesktopOnly": false
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "obsidian-sample-plugin",
-  "version": "0.9.7",
-  "description": "This is a sample plugin for Obsidian (https://obsidian.md)",
+  "name": "notetweet",
+  "version": "0.2.1",
+  "description": "Post tweets from Obsidian",
   "main": "src/main.js",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",

--- a/src/Modals/SecureModeModal.ts
+++ b/src/Modals/SecureModeModal.ts
@@ -4,7 +4,9 @@ import {SecureModeCrypt} from "../SecureModeCrypt";
 
 export class SecureModeModal extends Modal {
     private _plugin: NoteTweet;
-    private _enable: boolean;
+    private readonly _enable: boolean;
+    public isOpen: boolean;
+    public userPressedCrypt: boolean = false;
 
     constructor(app: App, plugin: NoteTweet, enable: boolean) {
         super(app);
@@ -14,6 +16,7 @@ export class SecureModeModal extends Modal {
 
     onOpen() {
         let {contentEl} = this;
+        this.isOpen = true;
 
         contentEl.createEl("h1", {text: "Secure Mode Settings"});
         contentEl.createEl("p", {text: "Please enter your password below and then click the button below."})
@@ -27,6 +30,8 @@ export class SecureModeModal extends Modal {
             this._enable ?
                 await this.encryptKeysWithPassword(password) :
                 await this.decryptKeysWithPassword(password);
+
+            this.userPressedCrypt = true;
 
             this.close();
         })
@@ -44,6 +49,7 @@ export class SecureModeModal extends Modal {
     onClose() {
         let {contentEl} = this;
         contentEl.empty();
+        this.isOpen = false;
     }
 
     private async encryptKeysWithPassword(password: string) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -60,10 +60,26 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
                 .setTooltip('Toggle Secure Mode')
                 .setValue(this.plugin.settings.secureMode)
                 .onChange(async value => {
-                    this.plugin.settings.secureMode = value;
-                    await this.plugin.saveSettings();
+                    if (value == this.plugin.settings.secureMode) return;
+                    let secureModeModal = new SecureModeModal(this.app, this.plugin, value);
+                    secureModeModal.open();
 
-                    new SecureModeModal(this.app, this.plugin, value).open();
+                    let doOnModalClose = async () => {
+                        if (secureModeModal.isOpen) {
+                            setTimeout(await doOnModalClose, 200);
+                        }
+                        else {
+                            if (secureModeModal.userPressedCrypt) {
+                                this.plugin.settings.secureMode = value;
+                                await this.plugin.saveSettings();
+                            }
+
+                            toggle.setValue(this.plugin.settings.secureMode);
+                            this.display(); // To update api-key values displayed to user (visual feedback).
+                        }
+                    }
+
+                    await doOnModalClose();
                 })
             )
     }


### PR DESCRIPTION
Check if the user enters an encryption key (password) and act accordingly:
- Don't update secure mode toggle if keys weren't en/decrypted
- Updates displayed keys on encrypt/decrypt
