### PR TITLE
Migrate to Twitter V2 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "crypto-es": "1.2.7",
     "got": "11.8.2",
-    "twitter-api-client": "1.3.2",
+    "twitter-api-v2": "^1.15.2",
     "uuid": "8.3.2"
   }
 }

--- a/src/Modals/NewTweetModal.ts
+++ b/src/Modals/NewTweetModal.ts
@@ -39,7 +39,6 @@ export class NewTweetModal extends PostTweetModal<IScheduledTweet | ITweet> {
 
     private postTweets() {
         return async () => {
-            console.log("asd");
             const threadContent: string[] = this.getThreadContent();
             if (!threadContent) return;
 

--- a/src/Modals/TweetsPostedModal/TweetsPostedModal.ts
+++ b/src/Modals/TweetsPostedModal/TweetsPostedModal.ts
@@ -1,10 +1,10 @@
 import { App, Modal, Notice } from "obsidian";
-import { StatusesUpdate } from "twitter-api-client";
+import { TweetV2PostTweetResult } from "twitter-api-v2";
 import { TwitterHandler } from "../../TwitterHandler";
 import TweetsPostedModalContent from "./TweetsPostedModalContent.svelte";
 
 export class TweetsPostedModal extends Modal {
-  private readonly posts: StatusesUpdate[];
+  private readonly posts: TweetV2PostTweetResult[];
   private readonly twitterHandler: TwitterHandler;
   private modalContent: TweetsPostedModalContent;
   private resolvePromise: () => void;
@@ -13,7 +13,7 @@ export class TweetsPostedModal extends Modal {
 
   constructor(
     app: App,
-    post: StatusesUpdate[],
+    post: TweetV2PostTweetResult[],
     twitterHandler: TwitterHandler
   ) {
     super(app);
@@ -37,7 +37,16 @@ export class TweetsPostedModal extends Modal {
 
   private deleteTweets() {
     return async () => {
-      let didDeleteTweets = await this.twitterHandler.deleteTweets(this.posts);
+      let tweetsToDelete = [];
+      for (const tweet of this.posts) {
+        tweetsToDelete.push({
+          id: tweet.data.id,
+          text: tweet.data.text,
+        });
+      }
+      let didDeleteTweets = await this.twitterHandler.deleteTweets(
+        tweetsToDelete
+      );
 
       if (didDeleteTweets) {
         this.userDeletedTweets = true;

--- a/src/Modals/TweetsPostedModal/TweetsPostedModalContent.svelte
+++ b/src/Modals/TweetsPostedModal/TweetsPostedModalContent.svelte
@@ -15,7 +15,7 @@
     {/if}
 
     {#each posts as post}
-        <a href="https://twitter.com/{post.user.screen_name}/status/{post.id_str}">{post.text}</a>
+        <a href="https://twitter.com/twitter/status/{post.data.id}">{post.data.text}</a>
         <br>
     {/each}
 

--- a/src/TwitterHandler.ts
+++ b/src/TwitterHandler.ts
@@ -1,13 +1,12 @@
-import { StatusesUpdate, TwitterClient } from "twitter-api-client";
+import { SendTweetV2Params, TweetV2, TwitterApi } from "twitter-api-v2";
 import NoteTweet from "./main";
-import {log} from "./ErrorModule/logManager";
+import { log } from "./ErrorModule/logManager";
 
 export class TwitterHandler {
-  private twitterClient: TwitterClient;
+  private twitterClient: TwitterApi;
   public isConnectedToTwitter = false;
 
-  constructor(private plugin: NoteTweet) {
-  }
+  constructor(private plugin: NoteTweet) {}
 
   public connectToTwitter(
     apiKey: string,
@@ -16,11 +15,11 @@ export class TwitterHandler {
     accessTokenSecret: string
   ) {
     try {
-      this.twitterClient = new TwitterClient({
-        apiKey,
-        apiSecret,
-        accessToken,
-        accessTokenSecret,
+      this.twitterClient = new TwitterApi({
+        appKey: apiKey,
+        appSecret: apiSecret,
+        accessToken: accessToken,
+        accessSecret: accessTokenSecret,
       });
       this.isConnectedToTwitter = true;
     } catch (e) {
@@ -29,71 +28,64 @@ export class TwitterHandler {
   }
 
   public async postThread(threadContent: string[]) {
-    let postedTweets: StatusesUpdate[] = [];
-    let previousPost: StatusesUpdate;
+    let tweets = [];
 
     for (const threadTweet of threadContent) {
-      let isFirstTweet = threadContent.indexOf(threadTweet) == 0;
-      const {tweet, media_ids} = await this.getImagesInTweet(threadTweet);
-
-      previousPost = await this.twitterClient.tweets.statusesUpdate({
-        status: tweet.trim(),
-        media_ids,
-        ...(!isFirstTweet && { in_reply_to_status_id: previousPost.id_str }),
-      });
-
-      postedTweets.push(previousPost);
+      const tweet: SendTweetV2Params = await this.constructTweet(threadTweet);
+      tweets.push(tweet);
     }
-
-    return postedTweets;
+    try {
+      return await this.twitterClient.v2.tweetThread(tweets);
+    } catch (e) {
+      console.log(`error in posting tweet thread: ${e}`);
+    }
   }
 
-  IMAGE_REGEX: RegExp = new RegExp(/!?\[\[([a-zA-Z 0-9-\.]*\.(gif|jpe?g|tiff?|png|webp|bmp))\]\]/);
-  public async postTweet(tweet: string) {
-    const {tweet: processedTweet, media_ids} = await this.getImagesInTweet(tweet);
+  IMAGE_REGEX: RegExp = new RegExp(
+    /!?\[\[([a-zA-Z 0-9-\.]*\.(gif|jpe?g|tiff?|png|webp|bmp))\]\]/
+  );
+  public async postTweet(tweetText: string) {
+    const tweet: SendTweetV2Params = await this.constructTweet(tweetText);
 
-    return await this.twitterClient.tweets.statusesUpdate({
-      status: processedTweet.trim(),
-      media_ids
-    });
+    try {
+      return await this.twitterClient.v2.tweet(tweet);
+    } catch (e) {
+      console.log(`error in posting tweet. ${e}`);
+    }
   }
 
-  private async getImagesInTweet(tweet: string): Promise<{ tweet: string, media_ids: string }> {
+  private async constructTweet(tweet: string): Promise<SendTweetV2Params> {
     let media_ids: string[] = [];
     let processedTweet = tweet;
 
     while (this.IMAGE_REGEX.test(processedTweet)) {
       const match = this.IMAGE_REGEX.exec(processedTweet);
       const fileName: string = match[1];
-
-      // Link in [[...]] might not be the actual path because of the attachment folder.
-      const file = this.plugin.app.vault.getFiles().find(f => f.name === fileName);
-      const fullPath = (await this.plugin.app.vault.readBinary(file));
-
-      const media_data = Buffer.from(fullPath).toString('base64');
-
-      const media_id = (await this.twitterClient.media.mediaUpload({media_data, media_category: "tweet_image"}));
+      const media_id = await this.twitterClient.v1.uploadMedia(fileName);
 
       if (media_id) {
-        media_ids.push(media_id.media_id_string);
+        media_ids.push(media_id);
         processedTweet = processedTweet.replace(this.IMAGE_REGEX, "");
       } else {
-        log.logWarning(`image '${fileName}' found but could not upload it to Twitter. Data is null/undefined: ${!!media_data}.`);
+        log.logWarning(
+          `image '${fileName}' found but could not upload it to Twitter. Data is null/undefined: ${!!media_ids}.`
+        );
       }
     }
 
-    return {tweet: processedTweet, media_ids: media_ids.join(",")}
+    return {
+      text: processedTweet,
+      ...(media_ids.length > 0 ? { media: { media_ids } } : {}),
+    };
   }
 
-  public async deleteTweets(tweets: StatusesUpdate[]) {
+  public async deleteTweets(tweets: TweetV2[]) {
     try {
       for (const tweet of tweets)
-        await this.twitterClient.tweets.statusesDestroyById({
-          id: tweet.id_str,
-        });
+        await this.twitterClient.v2.deleteTweet(tweet.id);
 
       return true;
-    } catch(e) {
+    } catch (e) {
       log.logError(`error in deleting tweets. ${e}`);
       return false;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import {ITweet} from "./Types/ITweet";
 import {IScheduledTweet} from "./Types/IScheduledTweet";
 import {Tweet} from "./Types/Tweet";
 import {ScheduledTweet} from "./Types/ScheduledTweet";
-import {StatusesUpdate} from "twitter-api-client";
+import {TweetV2PostTweetResult} from "twitter-api-v2";
 
 const WELCOME_MESSAGE: string = "Loading NoteTweet🐦. Thanks for installing.";
 const UNLOAD_MESSAGE: string = "Unloaded NoteTweet.";
@@ -136,7 +136,7 @@ export default class NoteTweet extends Plugin {
     if (tweet instanceof ScheduledTweet) {
       await this.scheduler.scheduleTweet(tweet);
     } else if (tweet instanceof Tweet) {
-      const tweetsPosted: StatusesUpdate[] = await this.twitterHandler.postThread(tweet.content);
+      const tweetsPosted: TweetV2PostTweetResult[] = await this.twitterHandler.postThread(tweet.content);
       new TweetsPostedModal(this.app, tweetsPosted, this.twitterHandler).open();
     }
   }
@@ -176,7 +176,7 @@ export default class NoteTweet extends Plugin {
 
       await postedModal.waitForClose;
       if (!postedModal.userDeletedTweets && this.settings.postTweetTag) {
-        postedTweets.forEach((tweet) => this.appendPostTweetTag(tweet.text));
+        postedTweets.forEach((tweet) => this.appendPostTweetTag(tweet.data.text));
       }
     } catch (e) {
       log.logError(`failed attempted to post tweets. ${e}`);
@@ -206,7 +206,7 @@ export default class NoteTweet extends Plugin {
 
         await postedModal.waitForClose;
         if (!postedModal.userDeletedTweets && this.settings.postTweetTag) {
-          await this.appendPostTweetTag(tweet.text);
+          await this.appendPostTweetTag(tweet.data.text);
         }
       } catch (e) {
         log.logError(`failed attempt to post selected. ${e}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "paths": {
       "src": ["src/*"]
     },
+    "ignoreDeprecations": "5.0",
     "importsNotUsedAsValues": "preserve"
   }
 }


### PR DESCRIPTION
The plugin broke when Twitter updated its API earlier this year, because the plugin uses Twitter's v1 API but the new API rules require using the v2 API endpoints for posting tweets.

The [old client library](https://www.npmjs.com/package/twitter-api-client) being currently used is no longer being maintained. So I migrated the plugin to the [twitter-api-v2 library](https://www.npmjs.com/package/twitter-api-v2?activeTab=readme), and I have been able to get it working again. Hopefully this will help other people who have been complaining about the plugin being broken. 