### PR TITLE
Toggle for auto-split tweets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ package-lock.json
 src/main.js
 *.js.map
 main.js
+
+# data
+data.json

--- a/src/Modals/NewTweetModal.ts
+++ b/src/Modals/NewTweetModal.ts
@@ -6,16 +6,19 @@ import {Tweet} from "../Types/Tweet";
 import {promptForDateTime} from "../utility";
 import {ScheduledTweet} from "../Types/ScheduledTweet";
 import {PostTweetModal} from "./PostTweetModal";
+import NoteTweet from "../main";
 
 export class NewTweetModal extends PostTweetModal<IScheduledTweet | ITweet> {
     static PostTweet(app: App, selection?: { text: string, thread: boolean }): Promise<ITweet | IScheduledTweet> {
-        const modal = new NewTweetModal(app, selection);
+        // Get plugin instance
+        const plugin = (app as any).plugins.plugins["notetweet"] as NoteTweet;
+        const modal = new NewTweetModal(app, plugin, selection);
         modal.open();
         return modal.newTweet;
     }
 
-    constructor(app: App, selection?: { text: string, thread: boolean }) {
-        super(app, selection);
+    constructor(app: App, plugin: NoteTweet, selection?: { text: string, thread: boolean }) {
+        super(app, plugin, selection);
     }
 
     protected addActionButtons() {

--- a/src/Modals/PostTweetModal.ts
+++ b/src/Modals/PostTweetModal.ts
@@ -16,11 +16,10 @@ export abstract class PostTweetModal<TPromise> extends Modal {
   public reject: (reason: any) => void;
   public resolve: (tweet: TPromise) => void;
 
-  protected constructor(app: App, selection?: { text: string; thread: boolean }) {
+  protected constructor(app: App, plugin: NoteTweet, selection?: { text: string; thread: boolean }) {
     super(app);
     this.selectedText = selection ?? {text: "", thread: false};
-    // Get the plugin instance from the app
-    this.plugin = (app as any).plugins.plugins["notetweet"];
+    this.plugin = plugin;
 
     this.newTweet = new Promise(((resolve, reject) => {
       this.resolve = (tweet => {
@@ -93,7 +92,8 @@ export abstract class PostTweetModal<TPromise> extends Modal {
   // Repeat this until all separated lines are joined into tweets with proper sizes.
   private textInputHandler(str: string) {
     // If auto-split is disabled, return the original string as a single chunk
-    if (!this.plugin?.settings?.autoSplitTweets) {
+    const autoSplitEnabled = this.plugin?.settings?.autoSplitTweets ?? true;
+    if (!autoSplitEnabled) {
       return [str];
     }
     
@@ -179,7 +179,8 @@ export abstract class PostTweetModal<TPromise> extends Modal {
       // Check if the pasted content would exceed the character limit
       if (pasted.length + textarea.textLength > this.MAX_TWEET_LENGTH) {
         // If auto-split is enabled, we should process the paste
-        if (this.plugin?.settings?.autoSplitTweets) {
+        const autoSplitEnabled = this.plugin?.settings?.autoSplitTweets ?? true;
+        if (autoSplitEnabled) {
           event.preventDefault();
           let splicedPaste = this.textInputHandler(pasted);
           this.createTweetsWithInput(splicedPaste, textarea, textZone);
@@ -206,7 +207,8 @@ export abstract class PostTweetModal<TPromise> extends Modal {
       }
 
       // Only auto-split tweets if the setting is enabled
-      if (key.code == "Enter" && textarea.textLength >= this.MAX_TWEET_LENGTH && this.plugin.settings.autoSplitTweets) {
+      const autoSplitEnabled = this.plugin?.settings?.autoSplitTweets ?? true;
+      if (key.code == "Enter" && textarea.textLength >= this.MAX_TWEET_LENGTH && autoSplitEnabled) {
         key.preventDefault();
         try {
           this.createTextarea(textZone);
@@ -314,7 +316,8 @@ export abstract class PostTweetModal<TPromise> extends Modal {
     const DEFAULT_COLOR = "#339900";
 
     // Show different message based on auto-split setting
-    if (strlen >= this.MAX_TWEET_LENGTH && !this.plugin?.settings?.autoSplitTweets) {
+    const autoSplitEnabled = this.plugin?.settings?.autoSplitTweets ?? true;
+    if (strlen >= this.MAX_TWEET_LENGTH && !autoSplitEnabled) {
       lengthCheckerEl.innerText = `${strlen} / 280 characters.`;
       lengthCheckerEl.style.color = "#ffcc00"; // Yellow color
     } else {
@@ -383,7 +386,8 @@ export abstract class PostTweetModal<TPromise> extends Modal {
 
     // If auto-split is disabled, we still need to check for empty tweets
     // but allow tweets that exceed the length limit
-    if (this.plugin?.settings?.autoSplitTweets) {
+    const autoSplitEnabled = this.plugin?.settings?.autoSplitTweets ?? true;
+    if (autoSplitEnabled) {
       if (
           threadContent.find(
               (txt) => txt.length > this.MAX_TWEET_LENGTH || txt == ""

--- a/src/Modals/PostTweetModal.ts
+++ b/src/Modals/PostTweetModal.ts
@@ -308,17 +308,18 @@ export abstract class PostTweetModal<TPromise> extends Modal {
     const DEFAULT_COLOR = "#339900";
 
     // Show different message based on auto-split setting
-    if (strlen >= this.MAX_TWEET_LENGTH && !this.plugin?.settings?.autoSplitTweets) {
-      lengthCheckerEl.innerHTML = `<span style="color:#cc3300">${strlen} / 280 characters. </span><span style="color:#cc3300;font-style:italic">Tweet exceeds Twitter's limit!</span>`;
-    } else {
-      lengthCheckerEl.innerText = `${strlen} / 280 characters.`;
+    lengthCheckerEl.innerText = `${strlen} / 280 characters.`;
 
-      // Apply color changes based on length
-      if (strlen <= WARN1) lengthCheckerEl.style.color = DEFAULT_COLOR;
-      if (strlen > WARN1) lengthCheckerEl.style.color = "#ffcc00";
-      if (strlen > WARN2) lengthCheckerEl.style.color = "#ff9966";
-      if (strlen >= this.MAX_TWEET_LENGTH) {
-        lengthCheckerEl.style.color = "#cc3300";
+    // Apply color changes based on length
+    if (strlen <= WARN1) lengthCheckerEl.style.color = DEFAULT_COLOR;
+    if (strlen > WARN1) lengthCheckerEl.style.color = "#ffcc00";
+    if (strlen > WARN2) lengthCheckerEl.style.color = "#ff9966";
+    if (strlen >= this.MAX_TWEET_LENGTH) {
+      // Use yellow instead of red for when auto-split is disabled
+      if (!this.plugin?.settings?.autoSplitTweets) {
+        lengthCheckerEl.style.color = "#ffcc00"; // Yellow color (less alarming)
+      } else {
+        lengthCheckerEl.style.color = "#cc3300"; // Red color (original warning)
       }
     }
   }

--- a/src/Modals/UpdateScheduledTweetModal.ts
+++ b/src/Modals/UpdateScheduledTweetModal.ts
@@ -6,16 +6,19 @@ import {Tweet} from "../Types/Tweet";
 import {promptForDateTime} from "../utility";
 import {ScheduledTweet} from "../Types/ScheduledTweet";
 import {PostTweetModal} from "./PostTweetModal";
+import NoteTweet from "../main";
 
 export class UpdateScheduledTweetModal extends PostTweetModal<IScheduledTweet> {
     static Update(app: App, tweet: IScheduledTweet): Promise<IScheduledTweet> {
-        const modal = new UpdateScheduledTweetModal(app, tweet);
+        // Get plugin instance
+        const plugin = (app as any).plugins.plugins["notetweet"] as NoteTweet;
+        const modal = new UpdateScheduledTweetModal(app, plugin, tweet);
         modal.open();
         return modal.newTweet;
     }
 
-    constructor(app: App, private tweet: IScheduledTweet) {
-        super(app);
+    constructor(app: App, plugin: NoteTweet, private tweet: IScheduledTweet) {
+        super(app, plugin);
     }
 
     protected createFirstTextarea() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -187,7 +187,7 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
     private addAutoSplitTweetsSetting() {
         new Setting(this.containerEl)
             .setName("Auto-split tweets")
-            .setDesc("Automatically split tweets at 280 characters. Disable this to allow tweets to exceed character limit.")
+            .setDesc("Automatically split tweets at 280 characters. Disable this to allow tweets to exceed character limit. Note: Posting tweets longer than 280 characters requires a paid X (Twitter) plan.")
             .addToggle(toggle => 
                 toggle.setTooltip('Toggle auto-splitting tweets')
                     .setValue(this.plugin.settings.autoSplitTweets)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@ export interface NoteTweetSettings {
   accessTokenSecret: string;
   postTweetTag: string;
   secureMode: boolean;
+  autoSplitTweets: boolean;
   scheduling: {enabled: boolean, url: string, password: string, cronStrings: string[]};
 }
 
@@ -20,6 +21,7 @@ export const DEFAULT_SETTINGS: NoteTweetSettings = Object.freeze({
   accessTokenSecret: "",
   postTweetTag: "",
   secureMode: false,
+  autoSplitTweets: true,
   scheduling: {enabled: false, url: "", password: "", cronStrings: []},
 });
 
@@ -53,6 +55,7 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
     this.addAccessTokenSetting();
     this.addAccessTokenSecretSetting();
     this.addTweetTagSetting();
+    this.addAutoSplitTweetsSetting();
     this.addSecureModeSetting();
     this.addSchedulerSetting();
   }
@@ -180,6 +183,20 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
           }
       );
   }
+
+    private addAutoSplitTweetsSetting() {
+        new Setting(this.containerEl)
+            .setName("Auto-split tweets")
+            .setDesc("Automatically split tweets at 280 characters. Disable this to allow tweets to exceed character limit.")
+            .addToggle(toggle => 
+                toggle.setTooltip('Toggle auto-splitting tweets')
+                    .setValue(this.plugin.settings.autoSplitTweets)
+                    .onChange(async value => {
+                        this.plugin.settings.autoSplitTweets = value;
+                        await this.plugin.saveSettings();
+                    })
+            );
+    }
 
     private addSchedulerSetting() {
         new Setting(this.containerEl)

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 .postTweetModal {
     max-width: 35rem;
-    width: 35rem;
+    width: 100%;
     overflow-y: auto;
     max-height: 50rem;
     padding-left: 0.5rem;
@@ -40,7 +40,7 @@ textarea:focus {
 
 .tweetTooltipBody {
     visibility: hidden;
-    width: 500px;
+    width: 100%;
     background-color: black;
     color: #fff;
     text-align: center;


### PR DESCRIPTION
The X API allows posts of more than 280 chars for users with a paid plan. This PR adds a toggle so users can turn off auto-splitting tweets. 