### PR TITLE
docs: update README for X API v2 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 ## NoteTweet🐦 for Obsidian
-This plugin allows you to post tweets directly from Obsidian.
+This plugin allows you to post to X (formerly Twitter) directly from Obsidian.
 
 [![Release](https://img.shields.io/github/v/release/chhoumann/notetweet_obsidian?style=for-the-badge)]()
 [![Github All Releases](https://img.shields.io/github/downloads/chhoumann/notetweet_obsidian/total.svg?style=for-the-badge&logo=appveyor)]()
 
 ### Features
-- Post tweets of selected text
+- Post to X (tweets) of selected text
 - Post threads from file
-- Automatically appends a tag to your tweet (to keep track of what you've posted)
+- Automatically appends a tag to your post (to keep track of what you've posted)
 - **Secure mode** - encrypts your API keys such that they can only be accessed with a password.
-- Delete tweet/thread that was just posted (undo)
-- Post Tweet Mode - a modal dedicated to writing tweets and threads.
+- Delete post/thread that was just posted (undo)
+- Post Mode - a modal dedicated to writing posts and threads.
 - Images are supported - just include a `[[link]]` to your images!
-- Scheduling tweets - follow [this guide](./GuideToSettingUpScheduler.md) to set it up.
+- Scheduling posts - follow [this guide](./GuideToSettingUpScheduler.md) to set it up.
 
 
 Feel free to recommend features!
@@ -34,31 +34,42 @@ If you want to watch a video on how to set up this plugin, click [here](https://
 4. Proceed to Setup
 
 #### Setup
-1. Go to https://apps.twitter.com/app/new and create a new app. Make sure it is Read + Write (otherwise you can't tweet).
-2. Get your API key & secret and access token & secret.
-3. Paste those into the plugin settings.
+1. Go to [developer.x.com](https://developer.x.com) and sign up for a developer account if you haven't already.
+2. Navigate to the [Developer Portal](https://developer.x.com/en/portal/products/free) and create a new Project.
+3. Within your Project, create a new App. Make sure to enable **Read and Write** permissions (required for posting).
+4. In your App settings, navigate to the "Keys and tokens" section.
+5. Generate and save the following credentials:
+   - **API Key and API Key Secret** (used for OAuth 1.0a authentication)
+   - **Access Token and Access Token Secret** (represents your account for posting)
+6. Paste these four values into the plugin settings in Obsidian.
+
+**Important Notes:**
+- Store your credentials securely - they only display once in the developer portal
+- If you lose them, you'll need to regenerate new ones
+- Ensure your App has "Read and Write" permissions, not just "Read"
+- Your App must be attached to a Project (this is now required for X API v2)
 
 You'll see an indicator which tells you if you're connected or not.
 
-## Post Tweet Mode
-Using the `Post Tweet` command, a new modal will open. There, you can craft threads - or single tweets.
+## Post Mode
+Using the `Post Tweet` command, a new modal will open. There, you can craft threads - or single posts.
 You can select both text or threads before using the command and it'll automatically port it into the modal. If the selected text is longer than 280 characters, it'll break it into a thread for you.
-You can paste text into the modal. If that text is longer than 280 characters, it'll also break it into multiple tweets.
+You can paste text into the modal. If that text is longer than 280 characters, it'll also break it into multiple posts.
 
-### Post Tweet Mode Shortcuts
-- `Backspace` to delete empty tweet
-- `Enter` to make new tweet if max length
-- `Alt + Enter` to make new tweet
-- `Ctrl + Enter` to insert a tweet below
-- `Shift + Enter` to insert a new tweet above
-- `Ctrl + ArrowUp` to focus tweet above
-- `Ctrl + ArrowDown` to focus tweet below
-- `Ctrl + Shift + ArrowUp` to move tweet up
-- `Ctrl + Shift + ArrowDown` to move tweet down
-- `Ctrl + Shift + Delete` to delete the tweet you have focused
+### Post Mode Shortcuts
+- `Backspace` to delete empty post
+- `Enter` to make new post if max length
+- `Alt + Enter` to make new post
+- `Ctrl + Enter` to insert a post below
+- `Shift + Enter` to insert a new post above
+- `Ctrl + ArrowUp` to focus post above
+- `Ctrl + ArrowDown` to focus post below
+- `Ctrl + Shift + ArrowUp` to move post up
+- `Ctrl + Shift + ArrowDown` to move post down
+- `Ctrl + Shift + Delete` to delete the post you have focused
 
 ## Quick-posts
-Single tweets are simple. Just select some text and use the `Post Selected as Tweet` command.
+Single posts are simple. Just select some text and use the `Post Selected as Tweet` command.
 
 **Threads** have a specific format. First off, it only detects the first thread in any file.
 
@@ -66,12 +77,12 @@ Format:
 ```
 THREAD START
 
-Here you can type the first tweet in your thread.
+Here you can type the first post in your thread.
 
 Spacing is fine.
 
 ---
-Separation between tweets is done using a newline and three dashes - just like you see above.
+Separation between posts is done using a newline and three dashes - just like you see above.
 
 ---
 Enjoy!
@@ -82,7 +93,7 @@ THREAD END
 Threads must start with `THREAD START` and end with `THREAD END`.
 
 
-## Scheduling Tweets
+## Scheduling Posts
 Follow [this guide](./GuideToSettingUpScheduler.md).
 
 ## Troubleshooting
@@ -90,26 +101,30 @@ Follow [this guide](./GuideToSettingUpScheduler.md).
 ### Authentication Error (401)
 If you're seeing "TypeError: Cannot read properties of undefined (reading 'data')" or authentication errors even though the plugin shows as "connected":
 
-1. **Verify your Twitter app is attached to a Project**
-   - Go to [developer.twitter.com](https://developer.twitter.com)
+1. **Verify your X app is attached to a Project**
+   - Go to [developer.x.com](https://developer.x.com)
    - Navigate to your app settings
-   - Ensure your app is attached to a Project (required for Twitter API v2)
+   - Ensure your app is attached to a Project (required for X API v2)
 
 2. **Check your system clock**
    - Authentication can fail if your system time is incorrect
    - Ensure your computer's clock is synchronized
 
 3. **Regenerate your access tokens**
-   - In the Twitter Developer Portal, regenerate your Access Token & Secret
+   - In the X Developer Portal, regenerate your Access Token & Secret
    - Update the plugin settings with the new tokens
 
 4. **Verify app permissions**
-   - Your Twitter app must have "Read and Write" permissions
+   - Your X app must have "Read and Write" permissions
    - If you recently changed permissions, regenerate your tokens
 
 5. **Check for token expiration**
-   - Twitter tokens can expire after extended periods of non-use
+   - X API tokens can expire after extended periods of non-use
    - Simply regenerating them often resolves this issue
+
+6. **Verify Basic access is sufficient**
+   - The free Basic tier should work for most use cases
+   - Check your usage limits in the developer portal if you're hitting rate limits
 
 ### Common Issues
 - **Media upload failures**: Ensure your image files are in a supported format (gif, jpg, jpeg, png, webp, bmp) and accessible in your vault.


### PR DESCRIPTION
## Summary
This PR updates the README documentation to reflect X's (formerly Twitter) current API setup process.

## Changes
- Updated all Twitter references to X throughout the documentation
- Updated developer portal URL from  to 
- Added new Project-based setup instructions (X now requires creating a Project first)
- Clarified credential names (API Key/Secret, Access Token/Secret)
- Added important notes about:
  - Credential security (only displayed once)
  - Required permissions (Read and Write)
  - Project attachment requirement for X API v2
- Enhanced troubleshooting section with X branding
- Added note about Basic access tier being sufficient for most use cases

## Context
The previous setup guide was outdated and referenced the old Twitter developer portal. X has changed their API onboarding process to require Projects, and the URLs have changed from twitter.com to x.com domains.

This update ensures users can successfully set up the NoteTweet plugin with the current X API.

Fixes #38