### PR TITLE
fix: parse thread markers line by line

### DIFF
--- a/src/tweet.test.ts
+++ b/src/tweet.test.ts
@@ -37,9 +37,9 @@ describe("parseThread", () => {
 
 	it("recognizes markers with surrounding whitespace", () => {
 		const text = [
-			"  THREAD START\t",
+			"   THREAD START\t",
 			"first tweet",
-			"\tTHREAD END  ",
+			"  THREAD END\t",
 		].join("\n");
 
 		expect(parseThread(text)).toEqual(["first tweet"]);
@@ -49,12 +49,41 @@ describe("parseThread", () => {
 		const text = [
 			"THREAD START",
 			"first tweet",
-			" \t---  ",
+			"   --- \t",
 			"second tweet",
 			"THREAD END",
 		].join("\n");
 
 		expect(parseThread(text)).toEqual(["first tweet", "second tweet"]);
+	});
+
+	it("preserves four-space and tab-indented code that resembles structure", () => {
+		const text = [
+			"THREAD START",
+			"first paragraph",
+			"",
+			"    THREAD END",
+			"    ---",
+			"\tTHREAD START",
+			"\t---",
+			"content after indented code",
+			"---",
+			"second tweet",
+			"THREAD END",
+		].join("\n");
+
+		expect(parseThread(text)).toEqual([
+			[
+				"first paragraph",
+				"",
+				"    THREAD END",
+				"    ---",
+				"\tTHREAD START",
+				"\t---",
+				"content after indented code",
+			].join("\n"),
+			"second tweet",
+		]);
 	});
 
 	it("removes structural blank lines without changing tweet body lines", () => {

--- a/src/tweet.test.ts
+++ b/src/tweet.test.ts
@@ -1,11 +1,55 @@
 import { parseThread, splitIntoTweets } from "./tweet";
 
 describe("parseThread", () => {
-	it("returns each tweet in order, trimmed", () => {
+	it("parses the exact issue #23 Markdown and its whitespace separator", () => {
 		const text = [
 			"THREAD START",
-			"  first tweet  ",
+			"When one of the horsemen entered and saw that Nero was dying, he attempted to stop the bleeding, but efforts to save Nero's life were unsuccessful. Nero's final words were \"Too late! This is fidelity!\"",
+			"",
+			"[Nero](https://en.wikipedia.org/wiki/Nero?wprov=sfti1)",
+			"",
+			"--- ",
+			"a stark contrast to the final words of his ancestor Augustus, but Latin makes everything seem like a great play",
+			"THREAD END",
+		].join("\n");
+
+		expect(parseThread(text)).toEqual([
+			[
+				"When one of the horsemen entered and saw that Nero was dying, he attempted to stop the bleeding, but efforts to save Nero's life were unsuccessful. Nero's final words were \"Too late! This is fidelity!\"",
+				"",
+				"[Nero](https://en.wikipedia.org/wiki/Nero?wprov=sfti1)",
+			].join("\n"),
+			"a stark contrast to the final words of his ancestor Augustus, but Latin makes everything seem like a great play",
+		]);
+	});
+
+	it("accepts CRLF newlines", () => {
+		const text = [
+			"THREAD START",
+			"first tweet",
 			"---",
+			"second tweet",
+			"THREAD END",
+		].join("\r\n");
+
+		expect(parseThread(text)).toEqual(["first tweet", "second tweet"]);
+	});
+
+	it("recognizes markers with surrounding whitespace", () => {
+		const text = [
+			"  THREAD START\t",
+			"first tweet",
+			"\tTHREAD END  ",
+		].join("\n");
+
+		expect(parseThread(text)).toEqual(["first tweet"]);
+	});
+
+	it("recognizes a separator with surrounding whitespace", () => {
+		const text = [
+			"THREAD START",
+			"first tweet",
+			" \t---  ",
 			"second tweet",
 			"THREAD END",
 		].join("\n");
@@ -13,22 +57,82 @@ describe("parseThread", () => {
 		expect(parseThread(text)).toEqual(["first tweet", "second tweet"]);
 	});
 
+	it("removes structural blank lines without changing tweet body lines", () => {
+		const text = [
+			"THREAD START",
+			"",
+			"  indented first line  ",
+			"",
+			"second paragraph",
+			"",
+			"---",
+			"",
+			"second tweet",
+			"",
+			"THREAD END",
+		].join("\n");
+
+		expect(parseThread(text)).toEqual([
+			"  indented first line  \n\nsecond paragraph",
+			"second tweet",
+		]);
+	});
+
+	it("ignores marker-like lines in surrounding fenced code", () => {
+		const text = [
+			"```text",
+			"THREAD START",
+			"not a thread",
+			"THREAD END",
+			"```",
+			"",
+			"THREAD START",
+			"actual first tweet",
+			"---",
+			"```text",
+			"---",
+			"THREAD END",
+			"```",
+			"actual second tweet",
+			"THREAD END",
+		].join("\n");
+
+		expect(parseThread(text)).toEqual([
+			"actual first tweet",
+			"```text\n---\nTHREAD END\n```\nactual second tweet",
+		]);
+	});
+
 	it("throws when THREAD START is missing", () => {
 		const text = ["some tweet", "THREAD END"].join("\n");
 
-		expect(() => parseThread(text)).toThrow(/THREAD START or THREAD END/);
+		expect(() => parseThread(text)).toThrow(/missing a THREAD START marker/);
 	});
 
 	it("throws when THREAD END is missing", () => {
 		const text = ["THREAD START", "some tweet"].join("\n");
 
-		expect(() => parseThread(text)).toThrow(/THREAD START or THREAD END/);
+		expect(() => parseThread(text)).toThrow(/missing a THREAD END marker/);
+	});
+
+	it("throws when the markers are reversed", () => {
+		const text = ["THREAD END", "some tweet", "THREAD START"].join("\n");
+
+		expect(() => parseThread(text)).toThrow(/appears before THREAD START/);
 	});
 
 	it("throws when the thread body is empty", () => {
 		const text = ["THREAD START", "THREAD END"].join("\n");
 
-		expect(() => parseThread(text)).toThrow(/write something/);
+		expect(() => parseThread(text)).toThrow(/thread is empty/i);
+	});
+
+	it.each([
+		["first", ["THREAD START", "---", "second", "THREAD END"]],
+		["middle", ["THREAD START", "first", "---", "", "---", "third", "THREAD END"]],
+		["last", ["THREAD START", "first", "---", "THREAD END"]],
+	])("throws when the %s tweet is empty", (_position, lines) => {
+		expect(() => parseThread(lines.join("\n"))).toThrow(/Tweet \d+ is empty/);
 	});
 });
 

--- a/src/tweet.ts
+++ b/src/tweet.ts
@@ -21,9 +21,10 @@ export interface ComposeResult {
 
 /**
  * Extract the tweets of a thread delimited by `THREAD START` / `THREAD END`,
- * split on a `---` line. Structural lines may have surrounding whitespace and
- * use LF or CRLF newlines. Marker-like lines inside fenced code are content,
- * not structure.
+ * split on a `---` line. Structural lines may have up to three leading spaces
+ * plus trailing spaces or tabs, matching Markdown's non-code indentation, and
+ * use LF or CRLF newlines. Marker-like lines inside fenced or indented code are
+ * content, not structure.
  *
  * Blank lines directly beside a marker or separator are structural padding and
  * are removed. Every other body character is preserved. Missing, reversed, and
@@ -33,10 +34,12 @@ export function parseThread(text: string): string[] {
 	const lines = text.split(/\r\n|\n|\r/);
 	const structuralLines = linesOutsideFencedCode(lines);
 	const startIndex = lines.findIndex(
-		(line, index) => structuralLines[index] && line.trim() === THREAD_START,
+		(line, index) =>
+			structuralLines[index] && isStructuralLine(line, THREAD_START),
 	);
 	const endIndex = lines.findIndex(
-		(line, index) => structuralLines[index] && line.trim() === THREAD_END,
+		(line, index) =>
+			structuralLines[index] && isStructuralLine(line, THREAD_END),
 	);
 
 	if (startIndex === -1) {
@@ -52,7 +55,7 @@ export function parseThread(text: string): string[] {
 	const segments: string[][] = [[]];
 	for (let index = startIndex + 1; index < endIndex; index++) {
 		const line = lines[index];
-		if (structuralLines[index] && line.trim() === "---") {
+		if (structuralLines[index] && isStructuralLine(line, "---")) {
 			segments.push([]);
 		} else {
 			segments[segments.length - 1].push(line);
@@ -72,6 +75,13 @@ export function parseThread(text: string): string[] {
 		}
 		return linesInTweet.join("\n");
 	});
+}
+
+/** Match a whole structural line without reclassifying Markdown indented code. */
+function isStructuralLine(line: string, structure: string): boolean {
+	const leadingSpaces = /^ */.exec(line)?.[0].length ?? 0;
+	if (leadingSpaces > 3) return false;
+	return line.slice(leadingSpaces).replace(/[ \t]+$/, "") === structure;
 }
 
 type Fence = { character: "`" | "~"; length: number };

--- a/src/tweet.ts
+++ b/src/tweet.ts
@@ -21,28 +21,100 @@ export interface ComposeResult {
 
 /**
  * Extract the tweets of a thread delimited by `THREAD START` / `THREAD END`,
- * split on a `---` line. Throws when the markers are missing or the thread is
- * empty.
+ * split on a `---` line. Structural lines may have surrounding whitespace and
+ * use LF or CRLF newlines. Marker-like lines inside fenced code are content,
+ * not structure.
+ *
+ * Blank lines directly beside a marker or separator are structural padding and
+ * are removed. Every other body character is preserved. Missing, reversed, and
+ * empty thread structures are rejected instead of producing malformed posts.
  */
 export function parseThread(text: string): string[] {
-	const lines = text.split("\n");
-	const startIndex = lines.indexOf(THREAD_START) + 1;
-	const endIndex = lines.indexOf(THREAD_END);
+	const lines = text.split(/\r\n|\n|\r/);
+	const structuralLines = linesOutsideFencedCode(lines);
+	const startIndex = lines.findIndex(
+		(line, index) => structuralLines[index] && line.trim() === THREAD_START,
+	);
+	const endIndex = lines.findIndex(
+		(line, index) => structuralLines[index] && line.trim() === THREAD_END,
+	);
 
-	if (startIndex === 0 || endIndex === -1) {
-		throw new Error("Failed to detect THREAD START or THREAD END");
+	if (startIndex === -1) {
+		throw new Error("Thread is missing a THREAD START marker.");
+	}
+	if (endIndex === -1) {
+		throw new Error("Thread is missing a THREAD END marker.");
+	}
+	if (endIndex < startIndex) {
+		throw new Error("THREAD END appears before THREAD START.");
 	}
 
-	const content = lines
-		.slice(startIndex, endIndex)
-		.join("\n")
-		.split("\n---\n");
-
-	if (content.length === 1 && content[0] === "") {
-		throw new Error("Please write something in your thread.");
+	const segments: string[][] = [[]];
+	for (let index = startIndex + 1; index < endIndex; index++) {
+		const line = lines[index];
+		if (structuralLines[index] && line.trim() === "---") {
+			segments.push([]);
+		} else {
+			segments[segments.length - 1].push(line);
+		}
 	}
 
-	return content.map((tweet) => tweet.trim());
+	const normalized = segments.map(trimStructuralBlankLines);
+	if (normalized.length === 1 && normalized[0].length === 0) {
+		throw new Error("Thread is empty. Add content between the thread markers.");
+	}
+
+	return normalized.map((linesInTweet, index) => {
+		if (linesInTweet.length === 0) {
+			throw new Error(
+				`Tweet ${index + 1} is empty. Add content between thread separators.`,
+			);
+		}
+		return linesInTweet.join("\n");
+	});
+}
+
+type Fence = { character: "`" | "~"; length: number };
+
+/** Mark lines whose Markdown position is outside a backtick or tilde fence. */
+function linesOutsideFencedCode(lines: string[]): boolean[] {
+	const outside: boolean[] = [];
+	let fence: Fence | null = null;
+
+	for (const line of lines) {
+		outside.push(fence === null);
+		if (fence) {
+			if (closesFence(line, fence)) fence = null;
+		} else {
+			fence = opensFence(line);
+		}
+	}
+
+	return outside;
+}
+
+function opensFence(line: string): Fence | null {
+	const match = /^[ \t]{0,3}(`{3,}|~{3,})/.exec(line);
+	if (!match) return null;
+	return {
+		character: match[1][0] as Fence["character"],
+		length: match[1].length,
+	};
+}
+
+function closesFence(line: string, fence: Fence): boolean {
+	const match = /^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/.exec(line);
+	return (
+		match?.[1][0] === fence.character && match[1].length >= fence.length
+	);
+}
+
+function trimStructuralBlankLines(lines: string[]): string[] {
+	let start = 0;
+	let end = lines.length;
+	while (start < end && lines[start].trim() === "") start++;
+	while (end > start && lines[end - 1].trim() === "") end--;
+	return lines.slice(start, end);
 }
 
 /**

--- a/tests/e2e/notetweet-runtime.test.ts
+++ b/tests/e2e/notetweet-runtime.test.ts
@@ -18,6 +18,18 @@ const ISSUE_23_THREAD = [
 	"THREAD END",
 ].join("\n");
 
+const INDENTED_CODE_THREAD = [
+	"THREAD START",
+	"first paragraph",
+	"",
+	"    THREAD END",
+	"    ---",
+	"content after indented code",
+	"---",
+	"second post",
+	"THREAD END",
+].join("\n");
+
 describe("NoteTweet runtime", () => {
 	test("passes the issue #23 file to X as two posts", async () => {
 		const { obsidian, sandbox } = getContext();
@@ -65,6 +77,58 @@ describe("NoteTweet runtime", () => {
 				"[Nero](https://en.wikipedia.org/wiki/Nero?wprov=sfti1)",
 			].join("\n"),
 			"a stark contrast to the final words of his ancestor Augustus, but Latin makes everything seem like a great play",
+		]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("preserves indented code that resembles thread structure", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("indented-code-thread.md");
+
+		await sandbox.writeNote({
+			path: "indented-code-thread.md",
+			body: INDENTED_CODE_THREAD,
+		});
+		await obsidian.open({ path: notePath });
+		await obsidian.waitForActiveFile(notePath);
+
+		await obsidian.dev.evalJson<boolean>(
+			`(() => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				window.__notetweetE2ECapturedThread = null;
+				plugin.twitter.isConnected = true;
+				plugin.twitter.postThread = async (thread) => {
+					window.__notetweetE2ECapturedThread = thread;
+					return [];
+				};
+				return true;
+			})()`,
+		);
+
+		await obsidian.command(`${PLUGIN_ID}:post-file-as-thread`).run();
+		await obsidian.waitFor(
+			() =>
+				obsidian.dev.evalJson<boolean>(
+					"Array.isArray(window.__notetweetE2ECapturedThread)",
+				),
+			{
+					...WAIT_OPTS,
+					message: "Indented-code thread did not reach the X posting boundary.",
+			},
+		);
+
+		const thread = await obsidian.dev.evalJson<string[]>(
+			"window.__notetweetE2ECapturedThread",
+		);
+		expect(thread).toEqual([
+			[
+				"first paragraph",
+				"",
+				"    THREAD END",
+				"    ---",
+				"content after indented code",
+			].join("\n"),
+			"second post",
 		]);
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});

--- a/tests/e2e/notetweet-runtime.test.ts
+++ b/tests/e2e/notetweet-runtime.test.ts
@@ -7,7 +7,68 @@ import {
 
 const getContext = createNoteTweetE2EHarness("notetweet-runtime");
 
+const ISSUE_23_THREAD = [
+	"THREAD START",
+	"When one of the horsemen entered and saw that Nero was dying, he attempted to stop the bleeding, but efforts to save Nero's life were unsuccessful. Nero's final words were \"Too late! This is fidelity!\"",
+	"",
+	"[Nero](https://en.wikipedia.org/wiki/Nero?wprov=sfti1)",
+	"",
+	"--- ",
+	"a stark contrast to the final words of his ancestor Augustus, but Latin makes everything seem like a great play",
+	"THREAD END",
+].join("\n");
+
 describe("NoteTweet runtime", () => {
+	test("passes the issue #23 file to X as two posts", async () => {
+		const { obsidian, sandbox } = getContext();
+		const notePath = sandbox.path("issue-23-thread.md");
+
+		await sandbox.writeNote({
+			path: "issue-23-thread.md",
+			body: ISSUE_23_THREAD,
+		});
+		await obsidian.open({ path: notePath });
+		await obsidian.waitForActiveFile(notePath);
+
+		await obsidian.dev.evalJson<boolean>(
+			`(() => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				window.__notetweetE2ECapturedThread = null;
+				plugin.twitter.isConnected = true;
+				plugin.twitter.postThread = async (thread) => {
+					window.__notetweetE2ECapturedThread = thread;
+					return [];
+				};
+				return true;
+			})()`,
+		);
+
+		await obsidian.command(`${PLUGIN_ID}:post-file-as-thread`).run();
+		await obsidian.waitFor(
+			() =>
+				obsidian.dev.evalJson<boolean>(
+					"Array.isArray(window.__notetweetE2ECapturedThread)",
+				),
+			{
+					...WAIT_OPTS,
+					message: "Post file as thread did not reach the X posting boundary.",
+			},
+		);
+
+		const thread = await obsidian.dev.evalJson<string[]>(
+			"window.__notetweetE2ECapturedThread",
+		);
+		expect(thread).toEqual([
+			[
+				"When one of the horsemen entered and saw that Nero was dying, he attempted to stop the bleeding, but efforts to save Nero's life were unsuccessful. Nero's final words were \"Too late! This is fidelity!\"",
+				"",
+				"[Nero](https://en.wikipedia.org/wiki/Nero?wprov=sfti1)",
+			].join("\n"),
+			"a stark contrast to the final words of his ancestor Augustus, but Latin makes everything seem like a great play",
+		]);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("registers its three production commands and omits the dev reload command", async () => {
 		const { obsidian } = getContext();
 


### PR DESCRIPTION
Parse thread markers and separators as Markdown lines instead of brittle substrings.

This fixes issue #23, where a separator such as `--- ` was left inside one oversized post. The parser now accepts LF and CRLF, recognizes surrounding whitespace on structural lines, ignores marker-like content in fenced and indented code, preserves tweet body text, and rejects missing, reversed, or empty thread structures with specific errors.

The regression suite covers the exact reported Markdown at the pure parser seam and through the live `Post file as thread` Obsidian command. The runtime test captures the parsed posts at the X boundary without making a network request.

Validation after rebasing onto `f6597446`:
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` - 73 tests passed
- `pnpm run typecheck:e2e`
- isolated Obsidian E2E - 9 tests passed on Obsidian 1.13.0
- isolated Obsidian `dev:errors` - no errors captured
- `git diff --check`

No settings, credential, or release-asset migration is required.

Fixes #23