### PR TITLE
fix: use X-weighted post lengths

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
 		"vitest": "^4.1.9"
 	},
 	"dependencies": {
-		"crypto-es": "^2.1.0"
+		"crypto-es": "^2.1.0",
+		"twitter-text": "3.1.0"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
 	},
 	"dependencies": {
 		"crypto-es": "^2.1.0",
-		"twitter-text": "3.1.0"
+		"twitter-text": "3.1.0",
+		"unicode-segmenter": "0.17.0"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       crypto-es:
         specifier: ^2.1.0
         version: 2.1.0
+      twitter-text:
+        specifier: 3.1.0
+        version: 3.1.0
     devDependencies:
       '@types/node':
         specifier: ^26.0.1
@@ -66,6 +69,10 @@ packages:
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
@@ -1136,6 +1143,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  core-js@2.6.12:
+    resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==}
+    deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
+
   crelt@1.0.7:
     resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
 
@@ -2019,6 +2030,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  punycode@1.4.1:
+    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2238,6 +2252,12 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
+  twemoji-parser@11.0.2:
+    resolution: {integrity: sha512-5kO2XCcpAql6zjdLwRwJjYvAZyDy3+Uj7v1ipBzLthQmDL7Ce19bEqHr3ImSNeoSW2OA8u02XmARbXHaNO8GhA==}
+
+  twitter-text@3.1.0:
+    resolution: {integrity: sha512-nulfUi3FN6z0LUjYipJid+eiwXvOLb8Ass7Jy/6zsXmZK3URte043m8fL3FyDzrK+WLpyqhHuR/TcARTN/iuGQ==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2444,6 +2464,8 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/types@7.29.7':
     dependencies:
@@ -3313,6 +3335,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  core-js@2.6.12: {}
 
   crelt@1.0.7: {}
 
@@ -4381,6 +4405,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  punycode@1.4.1: {}
+
   punycode@2.3.1: {}
 
   react-is@16.13.1: {}
@@ -4656,6 +4682,15 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  twemoji-parser@11.0.2: {}
+
+  twitter-text@3.1.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      core-js: 2.6.12
+      punycode: 1.4.1
+      twemoji-parser: 11.0.2
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       twitter-text:
         specifier: 3.1.0
         version: 3.1.0
+      unicode-segmenter:
+        specifier: 0.17.0
+        version: 0.17.0
     devDependencies:
       '@types/node':
         specifier: ^26.0.1
@@ -2304,6 +2307,9 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  unicode-segmenter@0.17.0:
+    resolution: {integrity: sha512-rN+u/LmZx2SISURhq2vy+JeQmmf+9lFVsdVgvFJHa6wL42h3ojnYaS/UK4Fgsjku9C2P23WB/JK5sQWeBaZt+A==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -4754,6 +4760,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@8.3.0: {}
+
+  unicode-segmenter@0.17.0: {}
 
   uri-js@4.4.1:
     dependencies:

--- a/src/Modals/ComposeTweetModal.ts
+++ b/src/Modals/ComposeTweetModal.ts
@@ -13,6 +13,7 @@ import {
 	type ComposeResult,
 } from "../tweet";
 import { promptForDateTime } from "../datetime";
+import { analyzeTweetText } from "../textAnalysis";
 
 export interface ComposeOptions {
 	/** Pre-filled thread, one entry per post (edit / thread-from-selection). */
@@ -345,9 +346,9 @@ export class ComposeTweetModal extends Modal {
 		}
 	}
 
-	/** Repaint one row's character count from its current length. */
+	/** Repaint one row's X-weighted character count. */
 	private update(row: PostRow): void {
-		const length = row.textarea.value.length;
+		const length = analyzeTweetText(row.textarea.value).weightedLength;
 		const remaining = MAX_TWEET_LENGTH - length;
 		const shown = remaining <= COUNTDOWN_FROM;
 		const over = this.autoSplit && length > MAX_TWEET_LENGTH;
@@ -393,10 +394,25 @@ export class ComposeTweetModal extends Modal {
 
 		if (!this.autoSplit) return;
 		const pasted = event.clipboardData?.getData("text") ?? "";
-		if (pasted.length + row.textarea.value.length <= MAX_TWEET_LENGTH) return;
+		const start = row.textarea.selectionStart;
+		const end = row.textarea.selectionEnd;
+		const combined =
+			row.textarea.value.slice(0, start) +
+			pasted +
+			row.textarea.value.slice(end);
+		if (analyzeTweetText(combined).weightedLength <= MAX_TWEET_LENGTH) return;
 		event.preventDefault();
-		this.fillPosts(splitIntoTweets(pasted), row);
+		this.replaceRowWithPosts(row, splitIntoTweets(combined));
 		this.refreshState();
+	}
+
+	private replaceRowWithPosts(row: PostRow, chunks: string[]): void {
+		const index = this.rows.indexOf(row);
+		row.textarea.value = chunks[0] ?? "";
+		this.update(row);
+		for (let offset = 1; offset < chunks.length; offset++) {
+			this.makeRow(chunks[offset], index + offset);
+		}
 	}
 
 	/** Save clipboard images into the vault, then attach them to the post. */
@@ -438,7 +454,8 @@ export class ComposeTweetModal extends Modal {
 
 		if (
 			(event.code === "Enter" &&
-				row.textarea.value.length >= MAX_TWEET_LENGTH &&
+				analyzeTweetText(row.textarea.value).weightedLength >=
+					MAX_TWEET_LENGTH &&
 				this.autoSplit) ||
 			(enter && event.altKey)
 		) {
@@ -582,7 +599,11 @@ export class ComposeTweetModal extends Modal {
 		}
 		if (
 			this.autoSplit &&
-			this.rows.some((row) => row.textarea.value.length > MAX_TWEET_LENGTH)
+			this.rows.some(
+				(row) =>
+					analyzeTweetText(row.textarea.value).weightedLength >
+					MAX_TWEET_LENGTH,
+			)
 		) {
 			return { ok: false, reason: "A post is over 280 characters" };
 		}

--- a/src/textAnalysis.test.ts
+++ b/src/textAnalysis.test.ts
@@ -1,0 +1,45 @@
+import { analyzeTweetText } from "./textAnalysis";
+
+describe("analyzeTweetText", () => {
+	it("matches X's documented weighted-count examples", () => {
+		expect(analyzeTweetText("Hello, world! 👋").weightedLength).toBe(16);
+		expect(analyzeTweetText("界").weightedLength).toBe(2);
+
+		for (const emoji of ["👾", "🙋🏽", "👨‍🎤", "👨‍👩‍👧‍👦"]) {
+			expect(analyzeTweetText(emoji).weightedLength).toBe(2);
+		}
+	});
+
+	it("counts every valid URL as 23 regardless of source length", () => {
+		expect(analyzeTweetText("https://example.com").weightedLength).toBe(23);
+		expect(
+			analyzeTweetText(`https://example.com/${"path/".repeat(100)}`)
+				.weightedLength,
+		).toBe(23);
+	});
+
+	it("normalizes canonically equivalent text before counting", () => {
+		const composed = analyzeTweetText("café");
+		const decomposed = analyzeTweetText("cafe\u0301");
+
+		expect(composed.weightedLength).toBe(4);
+		expect(decomposed.weightedLength).toBe(4);
+		expect(decomposed.normalizedText).toBe(composed.normalizedText);
+	});
+
+	it("exposes only whole-URL and whole-grapheme split boundaries", () => {
+		const family = "👨‍👩‍👧‍👦";
+		const url = `https://example.com/${"a".repeat(200)}`;
+		const analysis = analyzeTweetText(`A${family} ${url} Z`);
+		const pieces = analysis.boundaries.map((boundary, index) => {
+			const start = index === 0 ? 0 : analysis.boundaries[index - 1].index;
+			return analysis.normalizedText.slice(start, boundary.index);
+		});
+
+		expect(pieces).toContain(family);
+		expect(pieces).toContain(url);
+		expect(analysis.boundaries.at(-1)?.weightedLength).toBe(
+			analysis.weightedLength,
+		);
+	});
+});

--- a/src/textAnalysis.ts
+++ b/src/textAnalysis.ts
@@ -1,0 +1,65 @@
+import extractUrlsWithIndices from "twitter-text/dist/esm/extractUrlsWithIndices.js";
+import parseTweet from "twitter-text/dist/esm/parseTweet.js";
+
+// Deep ESM imports are deliberate: twitter-text's default export eagerly pulls
+// every autolinking API into the Obsidian bundle. The dependency is pinned so
+// this narrow official surface cannot drift underneath us.
+
+export interface TextBoundary {
+	/** UTF-16 index immediately after this indivisible URL or grapheme. */
+	index: number;
+	/** X-weighted length from the beginning of the normalized text. */
+	weightedLength: number;
+}
+
+export interface TweetTextAnalysis {
+	/** NFC text, matching the normalization X applies before counting. */
+	normalizedText: string;
+	/** X-weighted length, including transformed URLs and emoji sequences. */
+	weightedLength: number;
+	/** Whether twitter-text considers the normalized text a valid 280-char post. */
+	valid: boolean;
+	/** Safe split positions that never bisect a URL or Unicode grapheme. */
+	boundaries: TextBoundary[];
+}
+
+const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+/**
+ * Analyze post text with X's official twitter-text rules. This is the sole
+ * counting boundary used by the composer and splitter.
+ */
+export function analyzeTweetText(text: string): TweetTextAnalysis {
+	const normalizedText = text.normalize("NFC");
+	const parsed = parseTweet(normalizedText);
+	const urls = extractUrlsWithIndices(normalizedText);
+	const urlAt = new Map(urls.map((url) => [url.indices[0], url]));
+	const boundaries: TextBoundary[] = [];
+	let weightedLength = 0;
+	let skipUntil = 0;
+
+	for (const part of segmenter.segment(normalizedText)) {
+		if (part.index < skipUntil) continue;
+
+		const url = urlAt.get(part.index);
+		if (url) {
+			weightedLength += 23;
+			skipUntil = url.indices[1];
+			boundaries.push({ index: skipUntil, weightedLength });
+			continue;
+		}
+
+		weightedLength += parseTweet(part.segment).weightedLength;
+		boundaries.push({
+			index: part.index + part.segment.length,
+			weightedLength,
+		});
+	}
+
+	return {
+		normalizedText,
+		weightedLength: parsed.weightedLength,
+		valid: parsed.valid,
+		boundaries,
+	};
+}

--- a/src/textAnalysis.ts
+++ b/src/textAnalysis.ts
@@ -1,5 +1,6 @@
 import extractUrlsWithIndices from "twitter-text/dist/esm/extractUrlsWithIndices.js";
 import parseTweet from "twitter-text/dist/esm/parseTweet.js";
+import { graphemeSegments } from "unicode-segmenter/grapheme";
 
 // Deep ESM imports are deliberate: twitter-text's default export eagerly pulls
 // every autolinking API into the Obsidian bundle. The dependency is pinned so
@@ -23,8 +24,6 @@ export interface TweetTextAnalysis {
 	boundaries: TextBoundary[];
 }
 
-const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
-
 /**
  * Analyze post text with X's official twitter-text rules. This is the sole
  * counting boundary used by the composer and splitter.
@@ -38,7 +37,7 @@ export function analyzeTweetText(text: string): TweetTextAnalysis {
 	let weightedLength = 0;
 	let skipUntil = 0;
 
-	for (const part of segmenter.segment(normalizedText)) {
+	for (const part of graphemeSegments(normalizedText)) {
 		if (part.index < skipUntil) continue;
 
 		const url = urlAt.get(part.index);

--- a/src/tweet.test.ts
+++ b/src/tweet.test.ts
@@ -1,3 +1,4 @@
+import { analyzeTweetText } from "./textAnalysis";
 import { parseThread, splitIntoTweets } from "./tweet";
 
 describe("parseThread", () => {
@@ -250,5 +251,58 @@ describe("splitIntoTweets", () => {
 			"33333\n44444",
 			"55555\n66666",
 		]);
+	});
+
+	it("keeps a long URL whole and counts it as 23", () => {
+		const url = `https://example.com/${"a".repeat(300)}`;
+		const text = `prefix ${url} suffix`;
+
+		expect(splitIntoTweets(text)).toEqual([text]);
+		expect(analyzeTweetText(text).weightedLength).toBe(37);
+	});
+
+	it("never splits a URL when surrounding text crosses the limit", () => {
+		const url = `https://example.com/${"a".repeat(300)}`;
+		const chunks = splitIntoTweets(`${"a".repeat(258)} ${url} tail`);
+
+		expect(chunks).toHaveLength(2);
+		expect(chunks[1]).toContain(url);
+		expect(chunks.filter((chunk) => chunk.includes("https://"))).toHaveLength(1);
+		for (const chunk of chunks) {
+			expect(analyzeTweetText(chunk).weightedLength).toBeLessThanOrEqual(280);
+		}
+	});
+
+	it("splits CJK text at its weighted boundary", () => {
+		const chunks = splitIntoTweets("界".repeat(141));
+
+		expect(chunks).toEqual(["界".repeat(140), "界"]);
+	});
+
+	it("keeps extended emoji graphemes intact while splitting", () => {
+		const family = "👨‍👩‍👧‍👦";
+		const chunks = splitIntoTweets(family.repeat(141));
+
+		expect(chunks).toEqual([family.repeat(140), family]);
+		for (const chunk of chunks) {
+			expect(analyzeTweetText(chunk).weightedLength).toBeLessThanOrEqual(280);
+		}
+	});
+
+	it("normalizes combining sequences without changing their meaning", () => {
+		const chunks = splitIntoTweets("e\u0301".repeat(281));
+
+		expect(chunks).toEqual(["é".repeat(280), "é"]);
+	});
+
+	it("produces non-empty weighted-valid posts for mixed text", () => {
+		const text = `${"Latin ".repeat(60)}${"界".repeat(60)} ${"👨‍🎤".repeat(60)}`;
+		const chunks = splitIntoTweets(text);
+
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(chunk.trim()).not.toBe("");
+			expect(analyzeTweetText(chunk).weightedLength).toBeLessThanOrEqual(280);
+		}
 	});
 });

--- a/src/tweet.ts
+++ b/src/tweet.ts
@@ -1,3 +1,5 @@
+import { analyzeTweetText, type TextBoundary } from "./textAnalysis";
+
 export const MAX_TWEET_LENGTH = 280;
 
 export const THREAD_START = "THREAD START";
@@ -128,60 +130,92 @@ function trimStructuralBlankLines(lines: string[]): string[] {
 }
 
 /**
- * Greedily pack newline-separated lines into chunks no longer than `maxLength`,
- * preserving the newline between packed lines. A single line that is itself too
- * long is split on sentence boundaries and re-packed recursively, falling back
- * to a hard word/character wrap for unbreakable text.
+ * Split text into posts within X's weighted limit. Sentence and whitespace
+ * boundaries are preferred, while official URL entities and Unicode graphemes
+ * remain indivisible. Text is normalized to NFC, matching X's counting rules.
  */
 export function splitIntoTweets(
 	text: string,
 	maxLength: number = MAX_TWEET_LENGTH,
 ): string[] {
-	const chunks: string[] = [];
-
-	for (const line of text.split("\n")) {
-		if (line.length > maxLength) {
-			// `replace` instead of a lookbehind split: lookbehinds crash the
-			// regex engine on iOS < 16.4, which Obsidian still supports.
-			const bySentence = line.replace(/([.?!])\s/g, "$1\n");
-			// A line with no sentence boundary won't shrink by re-splitting, so
-			// fall back to a hard word/character wrap to guarantee progress.
-			const pieces =
-				bySentence === line
-					? hardWrap(line, maxLength)
-					: splitIntoTweets(bySentence, maxLength);
-			chunks.push(...pieces);
-			continue;
-		}
-
-		const last = chunks.length - 1;
-		const combined = last < 0 ? line : `${chunks[last]}\n${line}`;
-		if (last >= 0 && combined.length <= maxLength) {
-			chunks[last] = combined;
-		} else {
-			chunks.push(line);
-		}
+	if (!Number.isFinite(maxLength) || maxLength <= 0) {
+		throw new RangeError("Tweet length must be a positive number.");
 	}
 
-	return chunks.filter((chunk) => chunk.trim().length > 0);
+	const analysis = analyzeTweetText(text);
+	const { normalizedText, boundaries } = analysis;
+	if (analysis.weightedLength <= maxLength) {
+		return normalizedText.trim().length > 0 ? [normalizedText] : [];
+	}
+
+	const chunks: string[] = [];
+	let startIndex = 0;
+	let startBoundary = 0;
+	let consumedWeight = 0;
+
+	while (startBoundary < boundaries.length) {
+		const limit = findLimit(boundaries, startBoundary, consumedWeight, maxLength);
+		if (limit === startBoundary) {
+			throw new Error("A single URL or grapheme exceeds the tweet length limit.");
+		}
+
+		const endBoundary = chooseBreak(
+			normalizedText,
+			boundaries,
+			startBoundary,
+			limit,
+			startIndex,
+		);
+		const endIndex = boundaries[endBoundary - 1].index;
+		const chunk = normalizedText.slice(startIndex, endIndex).trim();
+		if (chunk.length > 0) chunks.push(chunk);
+
+		consumedWeight = boundaries[endBoundary - 1].weightedLength;
+		startBoundary = endBoundary;
+		startIndex = endIndex;
+	}
+
+	return chunks;
 }
 
-/**
- * Break an unbreakable line into pieces no longer than `maxLength`, preferring
- * the last space inside the window and falling back to a hard cut when a single
- * word exceeds the limit.
- */
-function hardWrap(text: string, maxLength: number): string[] {
-	const pieces: string[] = [];
-	let rest = text;
+function findLimit(
+	boundaries: TextBoundary[],
+	start: number,
+	consumedWeight: number,
+	maxLength: number,
+): number {
+	let end = start;
+	while (
+		end < boundaries.length &&
+		boundaries[end].weightedLength - consumedWeight <= maxLength
+	) {
+		end++;
+	}
+	return end;
+}
 
-	while (rest.length > maxLength) {
-		let cut = rest.lastIndexOf(" ", maxLength);
-		if (cut <= 0) cut = maxLength;
-		pieces.push(rest.slice(0, cut));
-		rest = rest.slice(cut).replace(/^\s+/, "");
+function chooseBreak(
+	text: string,
+	boundaries: TextBoundary[],
+	start: number,
+	limit: number,
+	startIndex: number,
+): number {
+	if (limit === boundaries.length) return limit;
+
+	let sentenceBreak = -1;
+	let whitespaceBreak = -1;
+	for (let index = start; index < limit; index++) {
+		const unitStart = index === start ? startIndex : boundaries[index - 1].index;
+		const unit = text.slice(unitStart, boundaries[index].index);
+		if (/^\s+$/u.test(unit)) whitespaceBreak = index + 1;
+		if (/[.?!]$/u.test(unit) && index + 1 < limit) {
+			const nextStart = boundaries[index].index;
+			const next = text.slice(nextStart, boundaries[index + 1].index);
+			if (/^\s+$/u.test(next)) sentenceBreak = index + 1;
+		}
 	}
 
-	if (rest.length > 0) pieces.push(rest);
-	return pieces;
+	if (sentenceBreak > start) return sentenceBreak;
+	return whitespaceBreak > start ? whitespaceBreak : limit;
 }

--- a/src/types/twitter-text.d.ts
+++ b/src/types/twitter-text.d.ts
@@ -1,0 +1,24 @@
+declare module "twitter-text/dist/esm/parseTweet.js" {
+	export interface ParsedTweet {
+		weightedLength: number;
+		valid: boolean;
+		permillage: number;
+		validRangeStart: number;
+		validRangeEnd: number;
+		displayRangeStart: number;
+		displayRangeEnd: number;
+	}
+
+	export default function parseTweet(text?: string): ParsedTweet;
+}
+
+declare module "twitter-text/dist/esm/extractUrlsWithIndices.js" {
+	export interface TwitterTextUrl {
+		url: string;
+		indices: [number, number];
+	}
+
+	export default function extractUrlsWithIndices(
+		text: string,
+	): TwitterTextUrl[];
+}

--- a/tests/e2e/notetweet-runtime.test.ts
+++ b/tests/e2e/notetweet-runtime.test.ts
@@ -256,6 +256,129 @@ describe("NoteTweet runtime", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("uses X-weighted counts for composer validation, paste splitting, and Enter", async () => {
+		const { obsidian } = getContext();
+		const result = await obsidian.dev.evalJson<{
+			states: Record<
+				string,
+				{ count: string; over: boolean; postDisabled: boolean }
+			>;
+			pasteLongUrlPrevented: boolean;
+			pasteSplit: { prevented: boolean; values: string[] };
+			enterCjkRows: number;
+			enterLongUrlRows: number;
+		}>(
+			`(() => {
+				const selector = ".postTweetModal textarea.tweetArea";
+				const close = () => {
+					for (let i = 0; i < 12 && document.querySelector(".postTweetModal"); i++) {
+						(document.activeElement ?? document.body).dispatchEvent(
+							new KeyboardEvent("keydown", { key: "Escape", code: "Escape", keyCode: 27, which: 27, bubbles: true }),
+						);
+					}
+				};
+				const open = () => {
+					close();
+					app.commands.executeCommandById(${JSON.stringify(`${PLUGIN_ID}:post-tweet`)});
+					return document.querySelector(selector);
+				};
+				const setValue = (value) => {
+					const area = document.querySelector(selector);
+					const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value").set;
+					setter.call(area, value);
+					area.dispatchEvent(new Event("input", { bubbles: true }));
+					return area;
+				};
+				const state = (value) => {
+					open();
+					setValue(value);
+					const result = {
+						count: document.querySelector(".postTweetModal .nt-count")?.textContent ?? "",
+						over: document.querySelector(".postTweetModal .nt-post")?.classList.contains("is-over") ?? false,
+						postDisabled: document.querySelector(".postTweetModal .nt-btn-cta")?.disabled ?? true,
+					};
+					close();
+					return result;
+				};
+				const paste = (value) => {
+					open();
+					const area = document.querySelector(selector);
+					const transfer = new DataTransfer();
+					transfer.setData("text/plain", value);
+					const event = new ClipboardEvent("paste", { clipboardData: transfer, bubbles: true, cancelable: true });
+					area.dispatchEvent(event);
+					const result = {
+						prevented: event.defaultPrevented,
+						values: Array.from(document.querySelectorAll(selector)).map((el) => el.value),
+					};
+					close();
+					return result;
+				};
+				const enterRows = (value) => {
+					open();
+					const area = setValue(value);
+					area.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", code: "Enter", keyCode: 13, which: 13, bubbles: true, cancelable: true }));
+					const rows = document.querySelectorAll(selector).length;
+					close();
+					return rows;
+				};
+
+				const longUrl = "https://example.com/" + "a".repeat(300);
+				const pasteSplit = paste("a".repeat(258) + " " + longUrl + " tail");
+				const result = {
+					states: {
+						longUrlAtLimit: state("a".repeat(256) + " " + longUrl),
+						familyEmoji: state("👨‍👩‍👧‍👦".repeat(140)),
+						cjkOver: state("界".repeat(141)),
+						combiningAtLimit: state("e\\u0301".repeat(280)),
+						latinAtLimit: state("a".repeat(280)),
+					},
+					pasteLongUrlPrevented: paste(longUrl).prevented,
+					pasteSplit,
+					enterCjkRows: enterRows("界".repeat(140)),
+					enterLongUrlRows: enterRows(longUrl),
+				};
+				close();
+				return result;
+			})()`,
+		);
+
+		expect(result.states.longUrlAtLimit).toEqual({
+			count: "0",
+			over: false,
+			postDisabled: false,
+		});
+		expect(result.states.familyEmoji).toEqual({
+			count: "0",
+			over: false,
+			postDisabled: false,
+		});
+		expect(result.states.cjkOver).toEqual({
+			count: "-2",
+			over: true,
+			postDisabled: true,
+		});
+		expect(result.states.combiningAtLimit).toEqual({
+			count: "0",
+			over: false,
+			postDisabled: false,
+		});
+		expect(result.states.latinAtLimit).toEqual({
+			count: "0",
+			over: false,
+			postDisabled: false,
+		});
+		expect(result.pasteLongUrlPrevented).toBe(false);
+		expect(result.pasteSplit.prevented).toBe(true);
+		expect(result.pasteSplit.values).toHaveLength(2);
+		expect(result.pasteSplit.values[1]).toContain(
+			`https://example.com/${"a".repeat(300)}`,
+		);
+		expect(result.enterCjkRows).toBe(2);
+		expect(result.enterLongUrlRows).toBe(1);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
 	test("splits a post into two on a triple line break", async () => {
 		const { obsidian } = getContext();
 		const areaSelector = ".postTweetModal textarea.tweetArea";


### PR DESCRIPTION
Count and split posts with X's weighted text rules so the composer matches what the API accepts.

The composer previously used JavaScript UTF-16 length everywhere. That rejected valid long URLs, emoji sequences, and canonically equivalent combining text, while allowing over-limit CJK text. Paste splitting could also cut a URL in half.

This change adds one text-analysis boundary backed by the official `twitter-text` parser. It exposes the weighted length plus NFC-normalized, URL- and grapheme-safe split boundaries, and routes counters, validation, paste handling, automatic splitting, and Enter-at-limit behavior through it. The official package is pinned and imported through its narrow ESM modules because its default export defeats tree-shaking.

The branch is rebased onto master at `1e60c6c`, preserving the ES2020 `deferred()` mobile-WebView contract from #50 and the line-oriented thread parser plus all regressions from #48. Grapheme boundaries use pinned `unicode-segmenter` 0.17.0 so safe splitting remains UAX #29-compliant without requiring `Intl.Segmenter` or a newer WebView.

Validation:
- `CI=true pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` - 83 tests passed
- `pnpm run typecheck:e2e`
- `pnpm run test:e2e` - 10 live Obsidian tests passed
- `git diff --check`

Live verification used isolated vault `notetweet-notetweet_obsidian` with Obsidian 1.13.0. The parser file-to-thread paths and weighted composer paths pass together, and `dev:errors` is empty.

The production bundle is 313,869 bytes. The audit found no Node-only imports, `Promise.withResolvers`, or `Intl.Segmenter` retained in `main.js`.

Release impact: patch-level bug fix. No settings or credential migration.

Fixes #29
