### PR TITLE
fix: support mobile WebViews without Promise.withResolvers

### DIFF
--- a/src/Modals/ComposeTweetModal.ts
+++ b/src/Modals/ComposeTweetModal.ts
@@ -5,6 +5,7 @@ import {
 	type TFile,
 	setIcon,
 } from "obsidian";
+import { deferred } from "../deferred";
 import { log } from "../log";
 import {
 	MAX_TWEET_LENGTH,
@@ -121,7 +122,7 @@ export class ComposeTweetModal extends Modal {
 		app: App,
 		options: ComposeOptions = {},
 	): Promise<ComposeResult | null> {
-		const { promise, resolve } = Promise.withResolvers<ComposeResult | null>();
+		const { promise, resolve } = deferred<ComposeResult | null>();
 		new ComposeTweetModal(app, options, resolve).open();
 		return promise;
 	}

--- a/src/Modals/InputPromptModal.ts
+++ b/src/Modals/InputPromptModal.ts
@@ -1,4 +1,5 @@
 import { type App, Modal, Setting } from "obsidian";
+import { deferred } from "../deferred";
 
 interface InputPromptOptions {
 	placeholder?: string;
@@ -19,7 +20,7 @@ export class InputPromptModal extends Modal {
 		header: string,
 		options: InputPromptOptions = {},
 	): Promise<string | null> {
-		const { promise, resolve } = Promise.withResolvers<string | null>();
+		const { promise, resolve } = deferred<string | null>();
 		new InputPromptModal(app, header, options, resolve).open();
 		return promise;
 	}

--- a/src/Modals/TweetsPostedModal.ts
+++ b/src/Modals/TweetsPostedModal.ts
@@ -1,4 +1,5 @@
 import { type App, Modal, Notice, Setting } from "obsidian";
+import { deferred } from "../deferred";
 import type { PostedTweet } from "../xApi";
 import type { TwitterClient } from "../twitter";
 
@@ -18,7 +19,7 @@ export class TweetsPostedModal extends Modal {
 		private readonly twitter: TwitterClient,
 	) {
 		super(app);
-		const { promise, resolve } = Promise.withResolvers<void>();
+		const { promise, resolve } = deferred<void>();
 		this.waitForClose = promise;
 		this.resolveClose = resolve;
 	}

--- a/src/deferred.test.ts
+++ b/src/deferred.test.ts
@@ -1,0 +1,19 @@
+import { deferred } from "./deferred";
+
+describe("deferred", () => {
+	it("resolves with a value", async () => {
+		const { promise, resolve } = deferred<string>();
+
+		resolve("ready");
+
+		await expect(promise).resolves.toBe("ready");
+	});
+
+	it("resolves void promises", async () => {
+		const { promise, resolve } = deferred<void>();
+
+		resolve();
+
+		await expect(promise).resolves.toBeUndefined();
+	});
+});

--- a/src/deferred.ts
+++ b/src/deferred.ts
@@ -1,0 +1,13 @@
+export interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T | PromiseLike<T>) => void;
+}
+
+/** ES2020-compatible equivalent of the resolve side of Promise.withResolvers. */
+export function deferred<T>(): Deferred<T> {
+	let resolve!: Deferred<T>["resolve"];
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}

--- a/src/xApi.ts
+++ b/src/xApi.ts
@@ -6,6 +6,7 @@
  */
 
 import { arrayBufferToBase64, requestUrl } from "obsidian";
+import { deferred } from "./deferred";
 import { oauth1Header, percentEncode, type OAuth1Credentials } from "./oauth1";
 
 export interface PostedTweet {
@@ -119,7 +120,7 @@ function processingInfoOf(json: unknown): ProcessingInfo | undefined {
 }
 
 function sleep(ms: number): Promise<void> {
-	const { promise, resolve } = Promise.withResolvers<void>();
+	const { promise, resolve } = deferred<void>();
 	window.setTimeout(resolve, ms);
 	return promise;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["DOM", "ES2024"],
+    "lib": ["DOM", "ES2020"],
     "types": ["node"]
   }
 }


### PR DESCRIPTION
Restore NoteTweet's composer and promise-backed UI flows on mobile WebViews that do not implement the ES2024 `Promise.withResolvers` API.

On an Android 14 emulator running Obsidian 1.12.7 and Chrome WebView 113, the current 0.6.6 build loaded and registered all three NoteTweet commands, but executing `NoteTweet: Post tweet` silently opened no modal. The runtime reported `Promise.withResolvers` as `undefined`, matching the API call made before the composer opens.

This replaces all four `Promise.withResolvers` uses with a small ES2020-compatible deferred helper. It also lowers the TypeScript library contract from ES2024 to ES2020 so future unsupported runtime APIs fail typecheck instead of reaching older mobile WebViews.

Android verification in the guarded `omd-scratch` vault:

- pre-fix bundle instantiated, but the post command produced no composer
- fixed `main.js` matched the deployed file byte-for-byte at `bfd19914bb2a8ee8b74fe002e0a162411d4d8a0132ef2575347b474244028925`
- `core_smoke` passed with `platform: mobile` and NoteTweet enabled
- the focused command probe opened `Compose post`, split `First post\n\n\nSecond post` into two post cards, rendered attachment controls, and closed through the visible mobile close button
- the same runtime still reported `Promise.withResolvers: undefined`, proving the fallback path rather than a host polyfill
- the captured log window contained no NoteTweet or WebView exception

Validation:

- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` - 63 tests passed
- `pnpm run typecheck:e2e`
- isolated desktop Obsidian E2E - 7 tests passed, including the composer flow
- isolated desktop `dev:errors` - no errors captured

There is no settings, Secret Storage, X API, or data migration impact.

Fixes #26
