### PR TITLE
feat: add multi-account posting

### DIFF
--- a/GuideToSettingUpScheduler.md
+++ b/GuideToSettingUpScheduler.md
@@ -25,7 +25,7 @@ You should now see a page such as this one:
 On this page, follow these steps:
 1. Set an app name.
 2. Choose the region closest to you.
-3. Set the `ACCESS_SECRET`, `ACCESS_TOKEN`, `API_KEY`, and `API_SECRET`. These are the same credentials you entered into NoteTweet - use the plain values you got from the X (Twitter) developer portal.
+3. Set the `ACCESS_SECRET`, `ACCESS_TOKEN`, `API_KEY`, and `API_SECRET` for the X account that should publish every scheduled post. The scheduler owns this posting identity independently from the named accounts in NoteTweet. Choosing an account in the NoteTweet composer does not change which account the scheduler uses.
 4. Set the `Origin` to `https://<YOUR_APP_NAME>.herokuapp.com`, where `<YOUR_APP_NAME>` should be replaced by the name of your app that you specified in (1). Save this somewhere, you'll need it in a bit.
 5. Set a password for your scheduler. Anyone with this password can tweet on your behalf, so make it secure. And I'd also recommend that it isn't your Twitter password.
 6. Click 'Deploy app' and wait for it to deploy.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This plugin allows you to post to X (formerly Twitter) directly from Obsidian.
 - **Composer** (`Post tweet`) - a modal for writing single tweets or threads. It pre-fills from your current selection: a `THREAD START`/`THREAD END` block becomes a pre-split thread, and other text is auto-split for you.
 - **Post selection as tweet** - posts the current editor selection as a single tweet, immediately.
 - **Post file as thread** - parses the first `THREAD START`/`THREAD END` block in the active note and posts it as a thread.
+- **Multiple X accounts** - define named accounts, choose one in the composer, and set the default used by quick-post commands.
 - **Encrypted credentials** - your API keys are kept in Obsidian's built-in encrypted Secret Storage, not in the plugin's `data.json`.
 - **Auto-split** - long text is split into a thread at 280 characters (toggle in settings). Disabling it allows longer tweets, which require a paid X plan.
 - **Images** - attach images to a post in the composer: hover a post and click the image button to pick one from your vault, or just paste an image straight in (it's saved to your vault, then uploaded). You can also embed one by typing a `[[wikilink]]` to an image file (gif, jpg, jpeg, png, webp, bmp) in the text. Uploads are desktop only.
@@ -46,22 +47,22 @@ If you want to watch a video on how to set up this plugin, click [here](https://
    - To save, X also requires a **Callback URI / Redirect URL**, a **Website URL**, and a **Type of App**. The plugin uses OAuth 1.0a with the Access Token below and never uses the callback redirect, so any valid values work: put `https://github.com/chhoumann/notetweet_obsidian` in both URL fields and pick **Web App, Automated App or Bot** for the type.
    - Open the **Keys and tokens** tab, find **Access Token and Secret**, and click **Generate**. This gives you the **Access Token** and **Access Token Secret**.
    - If you change App permissions *after* generating the Access Token, regenerate the Access Token - otherwise it stays read-only.
-5. Paste all four values - **API Key**, **API Key Secret**, **Access Token**, and **Access Token Secret** - into the plugin settings in Obsidian. They are stored in Obsidian's encrypted Secret Storage (see 'Credentials & security' below).
+5. In NoteTweet settings, add a named X account and paste all four values - **API Key**, **API Key Secret**, **Access Token**, and **Access Token Secret** - into that account. They are stored in Obsidian's encrypted Secret Storage (see 'Credentials & security' below). Repeat this setup for each X account you want to post from.
 
 **Important Notes:**
 - Credentials are shown only once in the developer portal - if you lose them, regenerate new ones.
 - Ensure your App has **Read and write** permissions, not just Read, and regenerate the Access Token after changing permissions.
 - Your App must be attached to a Project (required for X API v2). New apps are enrolled automatically; legacy apps must be attached manually.
 
-You'll see a connection indicator that tells you whether you're connected and, when a connection fails, the exact reason X returned (for example the `client-not-enrolled` message).
+Each account has its own connection test, which shows the exact reason X returned when verification fails (for example the `client-not-enrolled` message).
 
 ### Credentials & security
-Your API key, API secret, access token, and access token secret are kept in Obsidian's built-in encrypted Secret Storage (`app.secretStorage`), not in the plugin's `data.json`. Because Secret Storage is used, this plugin requires **Obsidian 1.13.0 or newer**.
+Account names, IDs, and the default account are stored in the plugin's `data.json`. Every account's API key, API secret, access token, and access token secret are kept separately in Obsidian's built-in encrypted Secret Storage (`app.secretStorage`). Because Secret Storage is used, this plugin requires **Obsidian 1.13.0 or newer**.
 
-**Migrating from an older version.** If you're upgrading from a version that stored credentials in `data.json`, the settings tab shows a **Migrate credentials** section at the top with a **Migrate now** button. Click it to move your existing credentials into Secret Storage. If you previously enabled the old password-based Secure Mode, the button first prompts for that password so it can decrypt your credentials before storing them - the migration is lossless. A one-time notice on load points you to settings, and once you've migrated, your credentials no longer live in `data.json`.
+**Migrating from an older version.** Credentials already held in NoteTweet's four fixed Secret Storage entries are moved automatically into a named **Default** account. If you're upgrading from a version that stored credentials in `data.json`, the settings tab instead shows a **Migrate credentials** section with a **Migrate now** button. If you previously enabled the old password-based Secure Mode, the button first prompts for that password so it can decrypt the values. Both paths preserve all four X credentials and remove the old credential path after migration.
 
 ## Composer
-Run the `Post tweet` command to open the composer, where you can craft threads or single tweets. If you have text selected, it is ported into the composer automatically: a `THREAD START`/`THREAD END` block opens as a pre-split thread, and any other text is auto-split into tweets when it exceeds 280 characters. You can also paste text in, and anything longer than 280 characters is split for you. The composer has a **Post** button, and a **Schedule** button when scheduling is enabled.
+Run the `Post tweet` command to open the composer, where you can choose a named X account and craft threads or single tweets. The configured default account is selected initially. If you have text selected, it is ported into the composer automatically: a `THREAD START`/`THREAD END` block opens as a pre-split thread, and any other text is auto-split into tweets when it exceeds 280 characters. You can also paste text in, and anything longer than 280 characters is split for you. The composer has a **Post** button, and a **Schedule** button when scheduling is enabled.
 
 ### Composer Shortcuts
 - `Backspace` to delete an empty post
@@ -74,9 +75,9 @@ Run the `Post tweet` command to open the composer, where you can craft threads o
 - `Ctrl + Shift + Delete` to delete the focused post
 
 ## Quick posts
-Single tweets are simple. Just select some text and run the `Post selection as tweet` command to post it immediately.
+Single tweets are simple. Select some text and run the `Post selection as tweet` command to post it immediately through the default account configured in NoteTweet settings.
 
-To post a thread straight from a note, run the `Post file as thread` command. It detects the first `THREAD START`/`THREAD END` block in the active note and posts it.
+To post a thread straight from a note, run the `Post file as thread` command. It detects the first `THREAD START`/`THREAD END` block in the active note and posts it through the same default account.
 
 **Threads** have a specific format. Only the first thread block in a file is detected.
 
@@ -100,7 +101,7 @@ THREAD END
 Threads must start with `THREAD START` and end with `THREAD END`, and individual tweets are separated by a line containing only `---`.
 
 ## Scheduling Posts
-Scheduling is optional and advanced. It posts through a self-hosted scheduler endpoint, and it requires the **Natural Language Dates** community plugin for entering times. Follow [this guide](./GuideToSettingUpScheduler.md) to set it up.
+Scheduling is optional and advanced. The self-hosted scheduler owns its own X credentials and therefore its own posting identity. Choosing an account in NoteTweet affects immediate posting only - a scheduled post is always sent by the account configured on the scheduler server. Scheduling also requires the **Natural Language Dates** community plugin for entering times. Follow [this guide](./GuideToSettingUpScheduler.md) to set it up.
 
 ## Troubleshooting
 

--- a/obsidian-e2e.config.mjs
+++ b/obsidian-e2e.config.mjs
@@ -14,6 +14,8 @@ export default {
 	// compiled main.js, so all three plugin artifacts are symlinked into the vault.
 	pluginArtifacts: ["manifest.json", "main.js", "styles.css"],
 	defaultData: {
+		accounts: [],
+		defaultAccountId: "",
 		postTweetTag: "",
 		autoSplitTweets: true,
 		scheduling: {

--- a/src/Modals/ComposeTweetModal.ts
+++ b/src/Modals/ComposeTweetModal.ts
@@ -14,6 +14,7 @@ import {
 } from "../tweet";
 import { promptForDateTime } from "../datetime";
 import { analyzeTweetText } from "../textAnalysis";
+import type { XAccount } from "../settings";
 
 export interface ComposeOptions {
 	/** Pre-filled thread, one entry per post (edit / thread-from-selection). */
@@ -26,6 +27,10 @@ export interface ComposeOptions {
 	submitLabel?: string;
 	/** Whether to split content at the character limit. Defaults to true. */
 	autoSplit?: boolean;
+	/** Accounts available for immediate posting. */
+	accounts?: XAccount[];
+	/** Account preselected when the composer opens. */
+	selectedAccountId?: string;
 }
 
 /** Character count starts showing once this many remain. */
@@ -116,6 +121,7 @@ export class ComposeTweetModal extends Modal {
 	private statusEl!: HTMLElement;
 	private postButton!: HTMLButtonElement;
 	private scheduleButton: HTMLButtonElement | null = null;
+	private selectedAccountId = "";
 	private submitted = false;
 	private result: ComposeResult | null = null;
 
@@ -140,6 +146,40 @@ export class ComposeTweetModal extends Modal {
 		return this.options.autoSplit ?? true;
 	}
 
+	private buildAccountPicker(root: HTMLElement): void {
+		const accounts = this.options.accounts ?? [];
+		if (this.options.submitLabel === "Update") return;
+
+		const picker = root.createDiv({ cls: "nt-account-picker" });
+		picker.createEl("label", { text: "Post from", attr: { for: "nt-account" } });
+		if (accounts.length === 0) {
+			picker.createSpan({
+				cls: "nt-account-empty",
+				text: "Add an X account in settings",
+			});
+			return;
+		}
+
+		const selected = accounts.some(
+			({ id }) => id === this.options.selectedAccountId,
+		)
+			? this.options.selectedAccountId
+			: accounts[0].id;
+		this.selectedAccountId = selected ?? "";
+		const select = picker.createEl("select", {
+			cls: "nt-account-select dropdown",
+			attr: { id: "nt-account", "aria-label": "X account" },
+		});
+		for (const account of accounts) {
+			select.createEl("option", { text: account.name, value: account.id });
+		}
+		select.value = this.selectedAccountId;
+		select.addEventListener("change", () => {
+			this.selectedAccountId = select.value;
+			this.refreshState();
+		});
+	}
+
 	onOpen(): void {
 		this.modalEl.addClass("nt-compose-modal");
 		this.contentEl.addClass("postTweetModal");
@@ -148,6 +188,7 @@ export class ComposeTweetModal extends Modal {
 				? "Edit scheduled post"
 				: "Compose post",
 		);
+		this.buildAccountPicker(this.contentEl);
 
 		this.thread = this.contentEl.createDiv({ cls: "nt-thread" });
 
@@ -278,7 +319,14 @@ export class ComposeTweetModal extends Modal {
 
 	private buildFooter(root: HTMLElement): void {
 		const footer = root.createDiv({ cls: "nt-footer" });
-		this.statusEl = footer.createDiv({ cls: "nt-footer-status" });
+		const context = footer.createDiv({ cls: "nt-footer-context" });
+		this.statusEl = context.createDiv({ cls: "nt-footer-status" });
+		if (this.options.allowSchedule) {
+			context.createDiv({
+				cls: "nt-scheduler-identity",
+				text: "Scheduled posts use the scheduler's posting identity.",
+			});
+		}
 
 		const actions = footer.createDiv({ cls: "nt-footer-actions" });
 		if (this.options.allowSchedule) {
@@ -378,7 +426,9 @@ export class ComposeTweetModal extends Modal {
 		const { ok, reason } = this.validate();
 		this.statusEl.setText(reason ?? "");
 		this.statusEl.toggleClass("is-blocked", Boolean(reason));
-		this.postButton.disabled = !ok;
+		const requiresAccount = this.options.submitLabel !== "Update";
+		this.postButton.disabled =
+			!ok || (requiresAccount && this.selectedAccountId === "");
 		if (this.scheduleButton) this.scheduleButton.disabled = !ok;
 	}
 
@@ -624,8 +674,14 @@ export class ComposeTweetModal extends Modal {
 	}
 
 	private submitPost(): void {
-		if (!this.validate().ok) return;
-		this.result = { content: this.collectContent() };
+		const requiresAccount = this.options.submitLabel !== "Update";
+		if (!this.validate().ok || (requiresAccount && !this.selectedAccountId)) return;
+		this.result = {
+			content: this.collectContent(),
+			...(this.selectedAccountId
+				? { accountId: this.selectedAccountId }
+				: {}),
+		};
 		this.submitted = true;
 		this.close();
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,10 @@
 import { type Editor, MarkdownView, Notice, Plugin } from "obsidian";
 import type { PostedTweet } from "./xApi";
-import { DEFAULT_SETTINGS, type NoteTweetSettings } from "./settings";
+import {
+	DEFAULT_SETTINGS,
+	normalizeAccountSettings,
+	type NoteTweetSettings,
+} from "./settings";
 import { NoteTweetSettingsTab } from "./settingsTab";
 import { TwitterClient } from "./twitter";
 import { SelfHostedScheduler } from "./scheduler";
@@ -9,11 +13,13 @@ import { TweetsPostedModal } from "./Modals/TweetsPostedModal";
 import { log } from "./log";
 import { parseThread, type ScheduledTweet } from "./tweet";
 import {
+	clearFixedTwitterSecrets,
 	type LegacyCredentialData,
 	legacyCredentialsPresent,
-	resolveCredentials,
 	resolveSchedulerPassword,
+	stageFixedSecretMigration,
 } from "./migration";
+import { getAccountCredentials, type TwitterCredentials } from "./secrets";
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
@@ -21,14 +27,18 @@ function errorMessage(error: unknown): string {
 
 export default class NoteTweet extends Plugin {
 	settings!: NoteTweetSettings;
-	twitter!: TwitterClient;
 	scheduler: SelfHostedScheduler | null = null;
 
 	async onload(): Promise<void> {
 		await this.loadSettings();
-
-		this.twitter = new TwitterClient(this.app);
-		await this.reconnect();
+		const migrated = stageFixedSecretMigration(this.app, this.settings);
+		if (migrated) {
+			await this.saveSettings();
+			clearFixedTwitterSecrets(this.app);
+			new Notice(
+				`NoteTweet: existing credentials moved to the ${migrated.name} account.`,
+			);
+		}
 		this.refreshScheduler();
 
 		this.addCommand({
@@ -59,20 +69,31 @@ export default class NoteTweet extends Plugin {
 	async loadSettings(): Promise<void> {
 		const loaded = ((await this.loadData()) ?? {}) as Record<string, unknown>;
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, loaded);
+		this.settings.accounts = Array.isArray(loaded.accounts)
+			? (loaded.accounts as NoteTweetSettings["accounts"])
+			: [];
 		this.settings.scheduling = Object.assign(
 			{},
 			DEFAULT_SETTINGS.scheduling,
 			this.settings.scheduling,
 		);
+		normalizeAccountSettings(this.settings);
 	}
 
 	async saveSettings(): Promise<void> {
 		await this.saveData(this.settings);
 	}
 
-	/** Connect using SecretStorage credentials (falling back to legacy plaintext). */
-	async reconnect(): Promise<boolean> {
-		return this.twitter.connect(resolveCredentials(this.app, this.legacyData()));
+	/** Build and verify an account-scoped client for one direct posting action. */
+	async connectAccount(accountId: string): Promise<TwitterClient> {
+		const client = new TwitterClient(this.app);
+		const exists = this.settings.accounts.some(({ id }) => id === accountId);
+		if (exists) await client.connect(getAccountCredentials(this.app, accountId));
+		return client;
+	}
+
+	async verifyCredentials(credentials: TwitterCredentials): Promise<boolean> {
+		return new TwitterClient(this.app).connect(credentials);
 	}
 
 	/** Rebuild the scheduler from current settings, or clear it when disabled. */
@@ -101,6 +122,8 @@ export default class NoteTweet extends Plugin {
 		const options: ComposeOptions = {
 			allowSchedule: this.settings.scheduling.enabled,
 			autoSplit: this.settings.autoSplitTweets,
+			accounts: this.settings.accounts,
+			selectedAccountId: this.settings.defaultAccountId,
 		};
 
 		const selection = this.currentSelection();
@@ -120,9 +143,10 @@ export default class NoteTweet extends Plugin {
 			return;
 		}
 
-		if (!(await this.ensureConnected())) return;
+		const client = await this.clientForAccount(result.accountId);
+		if (!client) return;
 		try {
-			await this.showPosted(await this.twitter.postThread(result.content));
+			await this.showPosted(await client.postThread(result.content), client);
 		} catch (error) {
 			log.error(`Failed to post tweet: ${errorMessage(error)}`);
 		}
@@ -133,11 +157,12 @@ export default class NoteTweet extends Plugin {
 			log.warning("Nothing is selected.");
 			return;
 		}
-		if (!(await this.ensureConnected())) return;
+		const client = await this.clientForAccount(this.settings.defaultAccountId);
+		if (!client) return;
 
 		try {
-			const posted = await this.twitter.postTweet(editor.getSelection());
-			await this.showPosted([posted]);
+			const posted = await client.postTweet(editor.getSelection());
+			await this.showPosted([posted], client);
 		} catch (error) {
 			log.error(`Failed to post tweet: ${errorMessage(error)}`);
 		}
@@ -158,9 +183,10 @@ export default class NoteTweet extends Plugin {
 			return;
 		}
 
-		if (!(await this.ensureConnected())) return;
+		const client = await this.clientForAccount(this.settings.defaultAccountId);
+		if (!client) return;
 		try {
-			await this.showPosted(await this.twitter.postThread(thread));
+			await this.showPosted(await client.postThread(thread), client);
 		} catch (error) {
 			log.error(`Failed to post thread: ${errorMessage(error)}`);
 		}
@@ -185,20 +211,28 @@ export default class NoteTweet extends Plugin {
 		}
 	}
 
-	private async ensureConnected(): Promise<boolean> {
-		if (this.twitter.isConnected) return true;
-		await this.reconnect();
-		if (this.twitter.isConnected) return true;
+	private async clientForAccount(
+		accountId: string | undefined,
+	): Promise<TwitterClient | null> {
+		if (!accountId) {
+			new Notice("NoteTweet: add an X account in settings first.");
+			return null;
+		}
+		const client = await this.connectAccount(accountId);
+		if (client.isConnected) return client;
 		new Notice(
-			"NoteTweet: not connected to X. Add your credentials in settings.",
+			"NoteTweet: that X account is not connected. Check its credentials in settings.",
 		);
-		return false;
+		return null;
 	}
 
-	private async showPosted(posts: PostedTweet[]): Promise<void> {
+	private async showPosted(
+		posts: PostedTweet[],
+		client: TwitterClient,
+	): Promise<void> {
 		if (posts.length === 0) return;
 
-		const modal = new TweetsPostedModal(this.app, posts, this.twitter);
+		const modal = new TweetsPostedModal(this.app, posts, client);
 		modal.open();
 		await modal.waitForClose;
 

--- a/src/migration.test.ts
+++ b/src/migration.test.ts
@@ -6,12 +6,19 @@ import {
 	legacyCredentialsEncrypted,
 	legacyCredentialsPresent,
 	readLegacyCredentials,
-	resolveCredentials,
 	resolveSchedulerPassword,
+	stageFixedSecretMigration,
+	clearFixedTwitterSecrets,
 	storeCredentials,
 	stripLegacyCredentials,
 } from "./migration";
-import { SECRET_IDS } from "./secrets";
+import {
+	LEGACY_TWITTER_SECRET_IDS,
+	SECRET_IDS,
+	accountSecretId,
+	getAccountCredentials,
+} from "./secrets";
+import { DEFAULT_SETTINGS } from "./settings";
 
 interface FakeSecretStorage {
 	getSecret(id: string): string | null;
@@ -131,10 +138,10 @@ describe("decryptLegacyValue", () => {
 });
 
 describe("storeCredentials", () => {
-	it("writes non-empty credentials and skips empty ones", () => {
+	it("writes credentials into one account namespace", () => {
 		const { app, store } = makeApp();
 
-		storeCredentials(app, {
+		storeCredentials(app, "personal", {
 			apiKey: "ak",
 			apiSecret: "",
 			accessToken: "at",
@@ -142,12 +149,14 @@ describe("storeCredentials", () => {
 			schedulerPassword: "sched-pw",
 		});
 
-		expect(store.get(SECRET_IDS.apiKey)).toBe("ak");
-		expect(store.get(SECRET_IDS.accessToken)).toBe("at");
-		expect(store.get(SECRET_IDS.accessTokenSecret)).toBe("ats");
+		expect(store.get(accountSecretId("personal", "apiKey"))).toBe("ak");
+		expect(store.get(accountSecretId("personal", "accessToken"))).toBe("at");
+		expect(store.get(accountSecretId("personal", "accessTokenSecret"))).toBe(
+			"ats",
+		);
 		expect(store.get(SECRET_IDS.schedulerPassword)).toBe("sched-pw");
-		// Empty credential is not persisted.
-		expect(store.has(SECRET_IDS.apiSecret)).toBe(false);
+		expect(store.get(accountSecretId("personal", "apiSecret"))).toBe("");
+		expect(store.has("notetweet-account-personal-undefined")).toBe(false);
 	});
 });
 
@@ -177,23 +186,22 @@ describe("stripLegacyCredentials", () => {
 	});
 });
 
-describe("resolveCredentials", () => {
-	it("returns SecretStorage credentials when all four are present", () => {
+describe("fixed SecretStorage migration", () => {
+	it("copies all four fixed secrets into a named default account", () => {
 		const { app } = makeApp({
-			[SECRET_IDS.apiKey]: "stored-ak",
-			[SECRET_IDS.apiSecret]: "stored-as",
-			[SECRET_IDS.accessToken]: "stored-at",
-			[SECRET_IDS.accessTokenSecret]: "stored-ats",
+			[LEGACY_TWITTER_SECRET_IDS.apiKey]: "stored-ak",
+			[LEGACY_TWITTER_SECRET_IDS.apiSecret]: "stored-as",
+			[LEGACY_TWITTER_SECRET_IDS.accessToken]: "stored-at",
+			[LEGACY_TWITTER_SECRET_IDS.accessTokenSecret]: "stored-ats",
 		});
-		// Legacy plaintext also present, but SecretStorage must win.
-		const data: LegacyCredentialData = {
-			apiKey: "legacy-ak",
-			apiSecret: "legacy-as",
-			accessToken: "legacy-at",
-			accessTokenSecret: "legacy-ats",
-		};
+		const settings = structuredClone(DEFAULT_SETTINGS);
 
-		expect(resolveCredentials(app, data)).toEqual({
+		const account = stageFixedSecretMigration(app, settings);
+
+		expect(account).toEqual({ id: "migrated-account", name: "Default" });
+		expect(settings.accounts).toEqual([account]);
+		expect(settings.defaultAccountId).toBe(account?.id);
+		expect(getAccountCredentials(app, account?.id ?? "")).toEqual({
 			apiKey: "stored-ak",
 			apiSecret: "stored-as",
 			accessToken: "stored-at",
@@ -201,39 +209,19 @@ describe("resolveCredentials", () => {
 		});
 	});
 
-	it("falls back to legacy plaintext when SecretStorage is empty and data is unencrypted", () => {
-		const { app } = makeApp();
-		const data: LegacyCredentialData = {
-			apiKey: "legacy-ak",
-			apiSecret: "legacy-as",
-			accessToken: "legacy-at",
-			accessTokenSecret: "legacy-ats",
-		};
-
-		expect(resolveCredentials(app, data)).toEqual({
-			apiKey: "legacy-ak",
-			apiSecret: "legacy-as",
-			accessToken: "legacy-at",
-			accessTokenSecret: "legacy-ats",
+	it("is idempotent and clears fixed secrets only when explicitly finalized", () => {
+		const { app, store } = makeApp({
+			[LEGACY_TWITTER_SECRET_IDS.apiKey]: "stored-ak",
 		});
-	});
+		const settings = structuredClone(DEFAULT_SETTINGS);
 
-	it("does not return encrypted legacy values, yielding the empty stored credentials instead", () => {
-		const { app } = makeApp();
-		const data: LegacyCredentialData = {
-			apiKey: "encrypted-ak",
-			apiSecret: "encrypted-as",
-			accessToken: "encrypted-at",
-			accessTokenSecret: "encrypted-ats",
-			secureMode: true,
-		};
+		stageFixedSecretMigration(app, settings);
+		stageFixedSecretMigration(app, settings);
+		expect(settings.accounts).toHaveLength(1);
+		expect(store.get(LEGACY_TWITTER_SECRET_IDS.apiKey)).toBe("stored-ak");
 
-		expect(resolveCredentials(app, data)).toEqual({
-			apiKey: "",
-			apiSecret: "",
-			accessToken: "",
-			accessTokenSecret: "",
-		});
+		clearFixedTwitterSecrets(app);
+		expect(store.get(LEGACY_TWITTER_SECRET_IDS.apiKey)).toBe("");
 	});
 });
 

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -1,11 +1,13 @@
 import type { App } from "obsidian";
 import {
+	LEGACY_TWITTER_SECRET_IDS,
 	SECRET_IDS,
-	getTwitterCredentials,
-	hasCompleteCredentials,
+	getSecret,
+	setAccountCredentials,
 	setSecret,
 	type TwitterCredentials,
 } from "./secrets";
+import type { NoteTweetSettings, XAccount } from "./settings";
 import { decryptLegacyValue } from "./legacyCrypt";
 
 /**
@@ -68,17 +70,57 @@ export function readLegacyCredentials(
 /** Write the migrated (already-decrypted) credentials into SecretStorage. */
 export function storeCredentials(
 	app: App,
+	accountId: string,
 	credentials: MigratableCredentials,
 ): void {
-	if (credentials.apiKey) setSecret(app, SECRET_IDS.apiKey, credentials.apiKey);
-	if (credentials.apiSecret)
-		setSecret(app, SECRET_IDS.apiSecret, credentials.apiSecret);
-	if (credentials.accessToken)
-		setSecret(app, SECRET_IDS.accessToken, credentials.accessToken);
-	if (credentials.accessTokenSecret)
-		setSecret(app, SECRET_IDS.accessTokenSecret, credentials.accessTokenSecret);
+	setAccountCredentials(app, accountId, credentials);
 	if (credentials.schedulerPassword)
 		setSecret(app, SECRET_IDS.schedulerPassword, credentials.schedulerPassword);
+}
+
+const MIGRATED_ACCOUNT_ID = "migrated-account";
+
+/**
+ * Copy the four fixed SecretStorage values used by NoteTweet 0.6 into one
+ * named account. The old keys are deliberately cleared only after settings
+ * metadata has been saved by the caller.
+ */
+export function stageFixedSecretMigration(
+	app: App,
+	settings: NoteTweetSettings,
+): XAccount | null {
+	const credentials: TwitterCredentials = {
+		apiKey: getSecret(app, LEGACY_TWITTER_SECRET_IDS.apiKey),
+		apiSecret: getSecret(app, LEGACY_TWITTER_SECRET_IDS.apiSecret),
+		accessToken: getSecret(app, LEGACY_TWITTER_SECRET_IDS.accessToken),
+		accessTokenSecret: getSecret(
+			app,
+			LEGACY_TWITTER_SECRET_IDS.accessTokenSecret,
+		),
+	};
+	if (!Object.values(credentials).some(Boolean)) return null;
+
+	let account = settings.accounts.find(
+		(candidate) => candidate.id === MIGRATED_ACCOUNT_ID,
+	);
+	if (!account) {
+		account = {
+			id: MIGRATED_ACCOUNT_ID,
+			name: settings.accounts.length === 0 ? "Default" : "Imported account",
+		};
+		settings.accounts.push(account);
+	}
+	if (!settings.accounts.some(({ id }) => id === settings.defaultAccountId)) {
+		settings.defaultAccountId = account.id;
+	}
+	setAccountCredentials(app, account.id, credentials);
+	return account;
+}
+
+export function clearFixedTwitterSecrets(app: App): void {
+	for (const id of Object.values(LEGACY_TWITTER_SECRET_IDS)) {
+		setSecret(app, id, "");
+	}
 }
 
 /** Remove the legacy credential fields from the persisted settings object. */
@@ -89,32 +131,6 @@ export function stripLegacyCredentials(data: LegacyCredentialData): void {
 	delete data.accessTokenSecret;
 	delete data.secureMode;
 	if (data.scheduling) delete data.scheduling.password;
-}
-
-/**
- * The credentials the plugin should connect with right now: SecretStorage when
- * populated, otherwise the legacy plaintext values so plaintext users keep
- * working until they migrate. Secure-mode (encrypted) values are never returned
- * here - those require the migration password first.
- */
-export function resolveCredentials(
-	app: App,
-	data: LegacyCredentialData,
-): TwitterCredentials {
-	const stored = getTwitterCredentials(app);
-	if (hasCompleteCredentials(stored)) return stored;
-
-	if (legacyCredentialsPresent(data) && !legacyCredentialsEncrypted(data)) {
-		const legacy = readLegacyCredentials(data);
-		return {
-			apiKey: legacy.apiKey,
-			apiSecret: legacy.apiSecret,
-			accessToken: legacy.accessToken,
-			accessTokenSecret: legacy.accessTokenSecret,
-		};
-	}
-
-	return stored;
 }
 
 export function resolveSchedulerPassword(

--- a/src/secrets.test.ts
+++ b/src/secrets.test.ts
@@ -1,8 +1,8 @@
 import type { App } from "obsidian";
 import {
-	SECRET_IDS,
+	accountSecretId,
 	getSecret,
-	getTwitterCredentials,
+	getAccountCredentials,
 	hasCompleteCredentials,
 	hasSecretStorage,
 	setSecret,
@@ -58,28 +58,31 @@ describe("getSecret / setSecret", () => {
 	it("round-trips a stored value", () => {
 		const app = makeApp();
 
-		setSecret(app, SECRET_IDS.apiKey, "secret-value");
+		setSecret(app, accountSecretId("personal", "apiKey"), "secret-value");
 
-		expect(getSecret(app, SECRET_IDS.apiKey)).toBe("secret-value");
+		expect(getSecret(app, accountSecretId("personal", "apiKey"))).toBe(
+			"secret-value",
+		);
 	});
 
 	it("returns an empty string for an unset id", () => {
-		expect(getSecret(makeApp(), SECRET_IDS.apiSecret)).toBe("");
+		expect(
+			getSecret(makeApp(), accountSecretId("personal", "apiSecret")),
+		).toBe("");
 	});
 });
 
-describe("getTwitterCredentials", () => {
-	it("reads the four Twitter secret ids into a credentials object", () => {
+describe("getAccountCredentials", () => {
+	it("reads four credentials scoped to the requested account", () => {
 		const app = makeApp({
-			[SECRET_IDS.apiKey]: "ak",
-			[SECRET_IDS.apiSecret]: "as",
-			[SECRET_IDS.accessToken]: "at",
-			[SECRET_IDS.accessTokenSecret]: "ats",
-			// The scheduler password lives outside TwitterCredentials.
-			[SECRET_IDS.schedulerPassword]: "should-not-appear",
+			[accountSecretId("personal", "apiKey")]: "ak",
+			[accountSecretId("personal", "apiSecret")]: "as",
+			[accountSecretId("personal", "accessToken")]: "at",
+			[accountSecretId("personal", "accessTokenSecret")]: "ats",
+			[accountSecretId("work", "apiKey")]: "other-ak",
 		});
 
-		expect(getTwitterCredentials(app)).toEqual({
+		expect(getAccountCredentials(app, "personal")).toEqual({
 			apiKey: "ak",
 			apiSecret: "as",
 			accessToken: "at",

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -4,15 +4,18 @@ import type { App } from "obsidian";
  * Stable SecretStorage keys owned by this plugin. Obsidian requires secret ids
  * to be lowercase alphanumeric with optional dashes.
  */
-export const SECRET_IDS = {
+export const LEGACY_TWITTER_SECRET_IDS = {
 	apiKey: "notetweet-api-key",
 	apiSecret: "notetweet-api-secret",
 	accessToken: "notetweet-access-token",
 	accessTokenSecret: "notetweet-access-token-secret",
+} as const;
+
+export const SECRET_IDS = {
 	schedulerPassword: "notetweet-scheduler-password",
 } as const;
 
-export type SecretId = (typeof SECRET_IDS)[keyof typeof SECRET_IDS];
+export type SecretId = string;
 
 export interface TwitterCredentials {
 	apiKey: string;
@@ -43,13 +46,55 @@ export function setSecret(app: App, id: SecretId, value: string): void {
 	app.secretStorage?.setSecret(id, value);
 }
 
-export function getTwitterCredentials(app: App): TwitterCredentials {
+const ACCOUNT_SECRET_SUFFIX = {
+	apiKey: "api-key",
+	apiSecret: "api-secret",
+	accessToken: "access-token",
+	accessTokenSecret: "access-token-secret",
+} as const satisfies Record<keyof TwitterCredentials, string>;
+const TWITTER_CREDENTIAL_FIELDS = Object.keys(
+	ACCOUNT_SECRET_SUFFIX,
+) as (keyof TwitterCredentials)[];
+
+export function accountSecretId(
+	accountId: string,
+	field: keyof TwitterCredentials,
+): string {
+	return `notetweet-account-${accountId}-${ACCOUNT_SECRET_SUFFIX[field]}`;
+}
+
+export function getAccountCredentials(
+	app: App,
+	accountId: string,
+): TwitterCredentials {
 	return {
-		apiKey: getSecret(app, SECRET_IDS.apiKey),
-		apiSecret: getSecret(app, SECRET_IDS.apiSecret),
-		accessToken: getSecret(app, SECRET_IDS.accessToken),
-		accessTokenSecret: getSecret(app, SECRET_IDS.accessTokenSecret),
+		apiKey: getSecret(app, accountSecretId(accountId, "apiKey")),
+		apiSecret: getSecret(app, accountSecretId(accountId, "apiSecret")),
+		accessToken: getSecret(app, accountSecretId(accountId, "accessToken")),
+		accessTokenSecret: getSecret(
+			app,
+			accountSecretId(accountId, "accessTokenSecret"),
+		),
 	};
+}
+
+export function setAccountCredentials(
+	app: App,
+	accountId: string,
+	credentials: TwitterCredentials,
+): void {
+	for (const field of TWITTER_CREDENTIAL_FIELDS) {
+		setSecret(app, accountSecretId(accountId, field), credentials[field]);
+	}
+}
+
+export function clearAccountCredentials(app: App, accountId: string): void {
+	setAccountCredentials(app, accountId, {
+		apiKey: "",
+		apiSecret: "",
+		accessToken: "",
+		accessTokenSecret: "",
+	});
 }
 
 /** All four Twitter credentials are present. Used by several connect paths. */

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -1,0 +1,46 @@
+import {
+	DEFAULT_SETTINGS,
+	normalizeAccountSettings,
+	type NoteTweetSettings,
+} from "./settings";
+
+describe("normalizeAccountSettings", () => {
+	it("preserves valid account metadata and its default", () => {
+		const settings: NoteTweetSettings = {
+			...structuredClone(DEFAULT_SETTINGS),
+			accounts: [
+				{ id: "personal", name: " Personal " },
+				{ id: "work-account", name: "Work" },
+			],
+			defaultAccountId: "work-account",
+		};
+
+		normalizeAccountSettings(settings);
+
+		expect(settings.accounts).toEqual([
+			{ id: "personal", name: "Personal" },
+			{ id: "work-account", name: "Work" },
+		]);
+		expect(settings.defaultAccountId).toBe("work-account");
+	});
+
+	it("drops unsafe or duplicate metadata and repairs an invalid default", () => {
+		const settings = {
+			...structuredClone(DEFAULT_SETTINGS),
+			accounts: [
+				{ id: "personal", name: "Personal" },
+				{ id: "personal", name: "Duplicate" },
+				{ id: "../unsafe", name: "Unsafe" },
+				{ id: "blank-name", name: "  " },
+			],
+			defaultAccountId: "missing",
+		};
+
+		normalizeAccountSettings(settings);
+
+		expect(settings.accounts).toEqual([
+			{ id: "personal", name: "Personal" },
+		]);
+		expect(settings.defaultAccountId).toBe("personal");
+	});
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,13 @@
+export interface XAccount {
+	id: string;
+	name: string;
+}
+
 export interface NoteTweetSettings {
+	/** Named X accounts. Credentials live separately in SecretStorage. */
+	accounts: XAccount[];
+	/** Account used by commands that do not show the composer. */
+	defaultAccountId: string;
 	/** Tag appended to a note's text after its tweet is posted (empty = off). */
 	postTweetTag: string;
 	/** Split pasted/typed content into multiple tweets at the 280-char limit. */
@@ -10,6 +19,8 @@ export interface NoteTweetSettings {
 }
 
 export const DEFAULT_SETTINGS: NoteTweetSettings = {
+	accounts: [],
+	defaultAccountId: "",
 	postTweetTag: "",
 	autoSplitTweets: true,
 	scheduling: {
@@ -17,3 +28,35 @@ export const DEFAULT_SETTINGS: NoteTweetSettings = {
 		url: "",
 	},
 };
+
+const ACCOUNT_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** Keep persisted account metadata safe for use in SecretStorage identifiers. */
+export function normalizeAccountSettings(settings: NoteTweetSettings): void {
+	const seen = new Set<string>();
+	settings.accounts = Array.isArray(settings.accounts)
+		? settings.accounts.filter((account): account is XAccount => {
+			if (
+				!account ||
+				typeof account.id !== "string" ||
+				!ACCOUNT_ID.test(account.id) ||
+				typeof account.name !== "string" ||
+				account.name.trim() === "" ||
+				seen.has(account.id)
+			) {
+				return false;
+			}
+			seen.add(account.id);
+			account.name = account.name.trim();
+			return true;
+		})
+		: [];
+
+	if (!seen.has(settings.defaultAccountId)) {
+		settings.defaultAccountId = settings.accounts[0]?.id ?? "";
+	}
+}
+
+export function createAccount(name: string): XAccount {
+	return { id: crypto.randomUUID(), name: name.trim() };
+}

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -12,9 +12,12 @@ import { log } from "./log";
 import {
 	SECRET_IDS,
 	type SecretId,
+	accountSecretId,
+	clearAccountCredentials,
 	getSecret,
 	hasSecretStorage,
 	setSecret,
+	type TwitterCredentials,
 } from "./secrets";
 import {
 	type LegacyCredentialData,
@@ -26,6 +29,7 @@ import {
 } from "./migration";
 import { InputPromptModal } from "./Modals/InputPromptModal";
 import { ScheduledTweetsModal } from "./Modals/ScheduledTweetsModal";
+import { createAccount, type XAccount } from "./settings";
 
 const RECONNECT_DELAY_MS = 800;
 
@@ -37,7 +41,7 @@ const RECONNECT_DELAY_MS = 800;
  * in the plugin's data file.
  */
 export class NoteTweetSettingsTab extends PluginSettingTab {
-	private statusEl: HTMLElement | null = null;
+	private readonly statusEls = new Map<string, HTMLElement>();
 	private reconnectTimer: number | null = null;
 
 	constructor(app: App, private readonly noteTweet: NoteTweet) {
@@ -47,6 +51,8 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
 	override getControlValue(key: string): unknown {
 		const settings = this.noteTweet.settings;
 		switch (key) {
+			case "defaultAccountId":
+				return settings.defaultAccountId;
 			case "postTweetTag":
 				return settings.postTweetTag;
 			case "autoSplitTweets":
@@ -63,6 +69,9 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
 	override async setControlValue(key: string, value: unknown): Promise<void> {
 		const settings = this.noteTweet.settings;
 		switch (key) {
+			case "defaultAccountId":
+				settings.defaultAccountId = String(value);
+				break;
 			case "postTweetTag":
 				settings.postTweetTag = String(value);
 				break;
@@ -89,7 +98,10 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
 	override getSettingDefinitions(): SettingDefinitionItem[] {
 		return [
 			this.migrationGroup(),
-			this.credentialsGroup(),
+			this.accountsGroup(),
+			...this.noteTweet.settings.accounts.map((account) =>
+				this.accountCredentialsGroup(account),
+			),
 			this.postingGroup(),
 			this.schedulingGroup(),
 		];
@@ -118,10 +130,10 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
 		};
 	}
 
-	private credentialsGroup(): SettingDefinitionGroup {
+	private accountsGroup(): SettingDefinitionGroup {
 		return {
 			type: "group",
-			heading: "X API credentials",
+			heading: "X accounts",
 			items: [
 				{
 					name: "Secret storage unavailable",
@@ -129,37 +141,105 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
 					visible: () => !hasSecretStorage(this.app),
 				},
 				{
+					name: "Default account",
+					desc: "Used by Post selection as tweet and Post file as thread. The composer lets you choose per post.",
+					visible: () => this.noteTweet.settings.accounts.length > 0,
+					control: {
+						type: "dropdown",
+						key: "defaultAccountId",
+						options: Object.fromEntries(
+							this.noteTweet.settings.accounts.map(({ id, name }) => [id, name]),
+						),
+					},
+				},
+				{
+					name: "Add account",
+					desc: "Create a named X account. Its four credentials are stored only in Obsidian Secret Storage.",
+					render: (setting: Setting) => {
+						setting.addButton((button) =>
+							button
+								.setButtonText("Add account")
+								.setCta()
+								.onClick(() => this.addAccount()),
+						);
+					},
+				},
+			],
+		};
+	}
+
+	private accountCredentialsGroup(account: XAccount): SettingDefinitionGroup {
+		return {
+			type: "group",
+			heading: account.name,
+			items: [
+				{
+					name: "Account name",
+					render: (setting: Setting) => {
+						setting.addText((text) =>
+							text.setValue(account.name).onChange(async (value) => {
+								const name = value.trim();
+								if (!name) return;
+								account.name = name;
+								await this.noteTweet.saveSettings();
+							}),
+						);
+					},
+				},
+				{
 					name: "Connection",
 					searchable: false,
 					render: (setting: Setting) => {
-						this.statusEl = setting.controlEl.createSpan();
-						this.refreshStatus();
+						const status = setting.controlEl.createSpan();
+						this.statusEls.set(account.id, status);
+						this.refreshStatus(account.id);
+						setting.addButton((button) =>
+							button
+								.setButtonText("Test")
+								.onClick(() => this.testConnection(account.id)),
+						);
 					},
 				},
-				this.secretRow(
+				this.accountSecretRow(
+					account.id,
 					"API key",
-					SECRET_IDS.apiKey,
+					"apiKey",
 					"Enter your API key",
 					"Your app's API Key (also called the Consumer Key), from Keys and tokens in the X developer portal.",
 				),
-				this.secretRow(
+				this.accountSecretRow(
+					account.id,
 					"API secret",
-					SECRET_IDS.apiSecret,
+					"apiSecret",
 					"Enter your API secret",
 					"Your app's API Key Secret (the Consumer Secret).",
 				),
-				this.secretRow(
+				this.accountSecretRow(
+					account.id,
 					"Access token",
-					SECRET_IDS.accessToken,
+					"accessToken",
 					"Enter your access token",
 					"Generate under Keys and tokens -> Access Token and Secret (requires Read and Write user authentication).",
 				),
-				this.secretRow(
+				this.accountSecretRow(
+					account.id,
 					"Access token secret",
-					SECRET_IDS.accessTokenSecret,
+					"accessTokenSecret",
 					"Enter your access token secret",
 					"The Access Token Secret shown when you generate the access token.",
 				),
+				{
+					name: "Remove account",
+					desc: "Remove this account and clear its credentials from Secret Storage.",
+					render: (setting: Setting) => {
+						setting.addButton((button) =>
+							button
+								.setButtonText("Remove")
+								.setDestructive()
+								.onClick(() => this.removeAccount(account)),
+						);
+					},
+				},
 			],
 		};
 	}
@@ -232,9 +312,10 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
 		};
 	}
 
-	private secretRow(
+	private accountSecretRow(
+		accountId: string,
 		name: string,
-		id: SecretId,
+		field: keyof TwitterCredentials,
 		placeholder: string,
 		desc?: string,
 	): SettingDefinition {
@@ -242,8 +323,11 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
 			name,
 			...(desc ? { desc } : {}),
 			render: (setting: Setting) =>
-				this.renderSecretInput(setting, id, placeholder, () =>
-					this.scheduleReconnect(),
+				this.renderSecretInput(
+					setting,
+					accountSecretId(accountId, field),
+					placeholder,
+					() => this.scheduleReconnect(accountId),
 				),
 		};
 	}
@@ -270,32 +354,72 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
 		return this.noteTweet.settings as unknown as LegacyCredentialData;
 	}
 
-	private refreshStatus(message?: string): void {
-		if (!this.statusEl) return;
-		if (message) {
-			this.statusEl.setText(message);
-			this.statusEl.removeClass("nt-status--ok", "nt-status--err");
-			return;
-		}
-		const { isConnected, lastError } = this.noteTweet.twitter;
-		let text: string;
-		if (isConnected) text = "Connected to X.";
-		else if (lastError) text = `Not connected: ${lastError}`;
-		else text = "Not connected. Enter your credentials.";
-		this.statusEl.setText(text);
-		this.statusEl.toggleClass("nt-status--ok", isConnected);
-		this.statusEl.toggleClass("nt-status--err", !isConnected);
+	private refreshStatus(
+		accountId: string,
+		message = "Not checked.",
+		connected?: boolean,
+	): void {
+		const statusEl = this.statusEls.get(accountId);
+		if (!statusEl) return;
+		statusEl.setText(message);
+		statusEl.toggleClass("nt-status--ok", connected === true);
+		statusEl.toggleClass("nt-status--err", connected === false);
 	}
 
-	private scheduleReconnect(): void {
+	private async testConnection(accountId: string): Promise<void> {
+		this.refreshStatus(accountId, "Verifying credentials...");
+		const client = await this.noteTweet.connectAccount(accountId);
+		if (client.isConnected) {
+			this.refreshStatus(accountId, "Connected to X.", true);
+			return;
+		}
+		const message = client.lastError
+			? `Not connected: ${client.lastError}`
+			: "Not connected. Enter all four credentials.";
+		this.refreshStatus(accountId, message, false);
+	}
+
+	private scheduleReconnect(accountId: string): void {
 		if (this.reconnectTimer !== null) window.clearTimeout(this.reconnectTimer);
-		this.refreshStatus("Verifying credentials...");
+		this.refreshStatus(accountId, "Waiting to verify...");
 		this.reconnectTimer = window.setTimeout(() => {
 			this.reconnectTimer = null;
-			void this.noteTweet.reconnect()
-				.catch(() => {})
-				.then(() => this.refreshStatus());
+			void this.testConnection(accountId);
 		}, RECONNECT_DELAY_MS);
+	}
+
+	private async addAccount(): Promise<void> {
+		const settings = this.noteTweet.settings;
+		const used = new Set(settings.accounts.map(({ name }) => name));
+		let number = settings.accounts.length + 1;
+		while (used.has(`Account ${number}`)) number += 1;
+		const account = createAccount(`Account ${number}`);
+		settings.accounts.push(account);
+		if (!settings.defaultAccountId) settings.defaultAccountId = account.id;
+		await this.noteTweet.saveSettings();
+		this.update();
+	}
+
+	private async removeAccount(account: XAccount): Promise<void> {
+		if (!window.confirm(`Remove the X account "${account.name}"?`)) return;
+
+		const settings = this.noteTweet.settings;
+		const previousAccounts = settings.accounts;
+		const previousDefault = settings.defaultAccountId;
+		settings.accounts = settings.accounts.filter(({ id }) => id !== account.id);
+		if (settings.defaultAccountId === account.id) {
+			settings.defaultAccountId = settings.accounts[0]?.id ?? "";
+		}
+		try {
+			await this.noteTweet.saveSettings();
+		} catch (error) {
+			settings.accounts = previousAccounts;
+			settings.defaultAccountId = previousDefault;
+			throw error;
+		}
+		clearAccountCredentials(this.app, account.id);
+		this.statusEls.delete(account.id);
+		this.update();
 	}
 
 	private openScheduledTweets(): void {
@@ -331,7 +455,7 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
 		}
 
 		if (encrypted) {
-			const ok = await this.noteTweet.twitter.connect(credentials);
+			const ok = await this.noteTweet.verifyCredentials(credentials);
 			if (!ok) {
 				log.error(
 					"Those credentials did not work. Check your password and try again.",
@@ -340,17 +464,17 @@ export class NoteTweetSettingsTab extends PluginSettingTab {
 			}
 		}
 
-		storeCredentials(this.app, credentials);
+		const settings = this.noteTweet.settings;
+		const account = createAccount(
+			settings.accounts.length === 0 ? "Default" : "Imported account",
+		);
+		settings.accounts.push(account);
+		if (!settings.defaultAccountId) settings.defaultAccountId = account.id;
+		storeCredentials(this.app, account.id, credentials);
 		stripLegacyCredentials(data);
 		await this.noteTweet.saveSettings();
-		// Re-run the connection test with the credentials we just migrated rather
-		// than reading them back from SecretStorage: the read can race its async
-		// write and leave the status stuck on "Not connected" right after a
-		// successful migration.
-		await this.noteTweet.twitter.connect(credentials);
 		this.noteTweet.refreshScheduler(credentials.schedulerPassword);
-		new Notice("NoteTweet: credentials moved to secure storage.");
-		this.refreshStatus();
+		new Notice(`NoteTweet: credentials moved to the ${account.name} account.`);
 		this.update();
 	}
 }

--- a/src/tweet.ts
+++ b/src/tweet.ts
@@ -18,6 +18,8 @@ export interface ScheduledTweet {
  */
 export interface ComposeResult {
 	content: string[];
+	/** Named account selected for immediate posting. Omitted for scheduling. */
+	accountId?: string;
 	postAt?: number;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,27 @@
 	padding: 0 2px;
 }
 
+.nt-account-picker {
+	display: flex;
+	align-items: center;
+	gap: 0.625rem;
+	margin: 0.25rem 0 0.75rem;
+	font-size: var(--font-ui-small);
+}
+
+.nt-account-picker label {
+	color: var(--text-muted);
+	font-weight: var(--font-semibold);
+}
+
+.nt-account-select {
+	min-width: 10rem;
+}
+
+.nt-account-empty {
+	color: var(--text-error);
+}
+
 /* ---- Thread ---- */
 .nt-thread {
 	display: flex;
@@ -324,10 +345,21 @@
 	background: var(--background-primary);
 }
 
-.nt-footer-status {
+.nt-footer-context {
 	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	font-size: var(--font-ui-smaller);
+}
+
+.nt-footer-status {
 	font-size: var(--font-ui-small);
 	color: var(--text-error);
+}
+
+.nt-scheduler-identity {
+	color: var(--text-faint);
 }
 
 .nt-footer-actions {

--- a/tests/e2e/notetweet-runtime.test.ts
+++ b/tests/e2e/notetweet-runtime.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "vitest";
 import {
 	createNoteTweetE2EHarness,
 	PLUGIN_ID,
+	RELOAD_OPTIONS,
 	WAIT_OPTS,
+	waitForNoteTweetReady,
 } from "./harness";
 
 const getContext = createNoteTweetE2EHarness("notetweet-runtime");
@@ -46,11 +48,18 @@ describe("NoteTweet runtime", () => {
 			`(() => {
 				const plugin = app.plugins.plugins.${PLUGIN_ID};
 				window.__notetweetE2ECapturedThread = null;
-				plugin.twitter.isConnected = true;
-				plugin.twitter.postThread = async (thread) => {
-					window.__notetweetE2ECapturedThread = thread;
-					return [];
-				};
+				window.__notetweetE2ECapturedAccount = null;
+				plugin.settings.accounts = [{ id: "parser-account", name: "Parser account" }];
+				plugin.settings.defaultAccountId = "parser-account";
+				plugin.connectAccount = async (accountId) => ({
+					isConnected: true,
+					lastError: null,
+					postThread: async (thread) => {
+						window.__notetweetE2ECapturedAccount = accountId;
+						window.__notetweetE2ECapturedThread = thread;
+						return [];
+					},
+				});
 				return true;
 			})()`,
 		);
@@ -78,6 +87,11 @@ describe("NoteTweet runtime", () => {
 			].join("\n"),
 			"a stark contrast to the final words of his ancestor Augustus, but Latin makes everything seem like a great play",
 		]);
+		expect(
+			await obsidian.dev.evalJson<string>(
+				"window.__notetweetE2ECapturedAccount",
+			),
+		).toBe("parser-account");
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
@@ -96,11 +110,18 @@ describe("NoteTweet runtime", () => {
 			`(() => {
 				const plugin = app.plugins.plugins.${PLUGIN_ID};
 				window.__notetweetE2ECapturedThread = null;
-				plugin.twitter.isConnected = true;
-				plugin.twitter.postThread = async (thread) => {
-					window.__notetweetE2ECapturedThread = thread;
-					return [];
-				};
+				window.__notetweetE2ECapturedAccount = null;
+				plugin.settings.accounts = [{ id: "parser-account", name: "Parser account" }];
+				plugin.settings.defaultAccountId = "parser-account";
+				plugin.connectAccount = async (accountId) => ({
+					isConnected: true,
+					lastError: null,
+					postThread: async (thread) => {
+						window.__notetweetE2ECapturedAccount = accountId;
+						window.__notetweetE2ECapturedThread = thread;
+						return [];
+					},
+				});
 				return true;
 			})()`,
 		);
@@ -130,6 +151,11 @@ describe("NoteTweet runtime", () => {
 			].join("\n"),
 			"second post",
 		]);
+		expect(
+			await obsidian.dev.evalJson<string>(
+				"window.__notetweetE2ECapturedAccount",
+			),
+		).toBe("parser-account");
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
@@ -269,6 +295,9 @@ describe("NoteTweet runtime", () => {
 			enterLongUrlRows: number;
 		}>(
 			`(() => {
+				const plugin = app.plugins.plugins.${PLUGIN_ID};
+				plugin.settings.accounts = [{ id: "weighted-account", name: "Weighted account" }];
+				plugin.settings.defaultAccountId = "weighted-account";
 				const selector = ".postTweetModal textarea.tweetArea";
 				const close = () => {
 					for (let i = 0; i < 12 && document.querySelector(".postTweetModal"); i++) {
@@ -341,6 +370,7 @@ describe("NoteTweet runtime", () => {
 				close();
 				return result;
 			})()`,
+			{ timeoutMs: 60_000 },
 		);
 
 		expect(result.states.longUrlAtLimit).toEqual({
@@ -432,6 +462,180 @@ describe("NoteTweet runtime", () => {
 				),
 			{ ...WAIT_OPTS, message: "Compose post modal did not close." },
 		);
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("posts through the account selected in the composer and explains scheduler identity", async () => {
+		const { obsidian, plugin } = getContext();
+		await plugin.updateDataAndReload(
+			() => ({
+				accounts: [
+					{ id: "personal", name: "Personal" },
+					{ id: "work", name: "Work" },
+				],
+				defaultAccountId: "personal",
+				postTweetTag: "",
+				autoSplitTweets: true,
+				scheduling: { enabled: true, url: "https://scheduler.example" },
+			}),
+			RELOAD_OPTIONS,
+		);
+		await waitForNoteTweetReady(obsidian);
+
+		try {
+			await obsidian.dev.evalJson<boolean>(
+				`(() => {
+					const plugin = app.plugins.plugins.${PLUGIN_ID};
+					window.__ntOriginalConnectAccount = plugin.connectAccount;
+					window.__ntAccountProbe = null;
+					plugin.connectAccount = async (accountId) => ({
+						isConnected: true,
+						lastError: null,
+						postThread: async (content) => {
+							window.__ntAccountProbe = { accountId, content };
+							return [{ data: { id: "e2e-post", text: content[0] } }];
+						},
+						postTweet: async (text) => ({ data: { id: "e2e-post", text } }),
+						deleteTweets: async () => true,
+					});
+					return app.commands.executeCommandById(${JSON.stringify(`${PLUGIN_ID}:post-tweet`)});
+				})()`,
+			);
+			await obsidian.waitFor(
+				() =>
+					obsidian.dev.evalJson<boolean>(
+						`Boolean(document.querySelector(".nt-account-select"))`,
+					),
+				{ ...WAIT_OPTS, message: "Composer account selector did not render." },
+			);
+
+			const composer = await obsidian.dev.evalJson<{
+				initialAccount: string;
+				schedulerCopy: string;
+			}>(
+				`(() => ({
+					initialAccount: document.querySelector(".nt-account-select").value,
+					schedulerCopy: document.querySelector(".nt-scheduler-identity")?.textContent ?? "",
+				}))()`,
+			);
+			expect(composer.initialAccount).toBe("personal");
+			expect(composer.schedulerCopy).toContain("scheduler's posting identity");
+
+			await obsidian.dev.evalJson<boolean>(
+				`(() => {
+					const select = document.querySelector(".nt-account-select");
+					select.value = "work";
+					select.dispatchEvent(new Event("change", { bubbles: true }));
+					const area = document.querySelector(".postTweetModal textarea.tweetArea");
+					area.value = "Posted from work";
+					area.dispatchEvent(new Event("input", { bubbles: true }));
+					document.querySelector(".postTweetModal .nt-btn-cta").click();
+					return true;
+				})()`,
+			);
+			await obsidian.waitFor(
+				() =>
+					obsidian.dev.evalJson<boolean>(
+						`Boolean(window.__ntAccountProbe && document.querySelector(".nt-posted-list"))`,
+					),
+				{ ...WAIT_OPTS, message: "Selected-account post did not complete." },
+			);
+			const posted = await obsidian.dev.evalJson<{
+				accountId: string;
+				content: string[];
+			}>(`window.__ntAccountProbe`);
+			expect(posted).toEqual({
+				accountId: "work",
+				content: ["Posted from work"],
+			});
+		} finally {
+			await obsidian.dev.evalJson<boolean>(
+				`(() => {
+					const plugin = app.plugins.plugins.${PLUGIN_ID};
+					if (window.__ntOriginalConnectAccount) plugin.connectAccount = window.__ntOriginalConnectAccount;
+					for (const button of document.querySelectorAll("button")) {
+						if (button.textContent === "Great!") button.click();
+					}
+					delete window.__ntOriginalConnectAccount;
+					delete window.__ntAccountProbe;
+					return true;
+				})()`,
+			);
+		}
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("quick-post selection uses the configured default account", async () => {
+		const { obsidian, plugin } = getContext();
+		const notePath = "nt-e2e-default-account.md";
+		await plugin.updateDataAndReload(
+			() => ({
+				accounts: [
+					{ id: "personal", name: "Personal" },
+					{ id: "work", name: "Work" },
+				],
+				defaultAccountId: "work",
+				postTweetTag: "",
+				autoSplitTweets: true,
+				scheduling: { enabled: false, url: "" },
+			}),
+			RELOAD_OPTIONS,
+		);
+
+		try {
+			await obsidian.dev.evalJsonAsync<boolean>(
+				`(async () => {
+					const existing = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+					if (existing) await app.vault.delete(existing);
+					const file = await app.vault.create(${JSON.stringify(notePath)}, "Quick post text");
+					await app.workspace.getLeaf(false).openFile(file);
+					const editor = app.workspace.activeLeaf.view.editor;
+					editor.setSelection({ line: 0, ch: 0 }, { line: 0, ch: 10 });
+					const plugin = app.plugins.plugins.${PLUGIN_ID};
+					window.__ntOriginalConnectAccount = plugin.connectAccount;
+					window.__ntQuickProbe = null;
+					plugin.connectAccount = async (accountId) => ({
+						isConnected: true,
+						lastError: null,
+						postTweet: async (text) => {
+							window.__ntQuickProbe = { accountId, text };
+							return { data: { id: "e2e-quick", text } };
+						},
+						postThread: async () => [],
+						deleteTweets: async () => true,
+					});
+					app.commands.executeCommandById(${JSON.stringify(`${PLUGIN_ID}:post-selected-as-tweet`)});
+					return true;
+				})()`,
+			);
+			await obsidian.waitFor(
+				() =>
+					obsidian.dev.evalJson<boolean>(
+						`Boolean(window.__ntQuickProbe && document.querySelector(".nt-posted-list"))`,
+					),
+				{ ...WAIT_OPTS, message: "Default-account quick post did not complete." },
+			);
+			const posted = await obsidian.dev.evalJson<{
+				accountId: string;
+				text: string;
+			}>(`window.__ntQuickProbe`);
+			expect(posted).toEqual({ accountId: "work", text: "Quick post" });
+		} finally {
+			await obsidian.dev.evalJsonAsync<boolean>(
+				`(async () => {
+					const plugin = app.plugins.plugins.${PLUGIN_ID};
+					if (window.__ntOriginalConnectAccount) plugin.connectAccount = window.__ntOriginalConnectAccount;
+					for (const button of document.querySelectorAll("button")) {
+						if (button.textContent === "Great!") button.click();
+					}
+					const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+					if (file) await app.vault.delete(file);
+					delete window.__ntOriginalConnectAccount;
+					delete window.__ntQuickProbe;
+					return true;
+				})()`,
+			);
+		}
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 

--- a/tests/e2e/notetweet-settings.test.ts
+++ b/tests/e2e/notetweet-settings.test.ts
@@ -24,6 +24,7 @@ type SettingsSnapshot = {
 	found: boolean;
 	headings: string[];
 	migrationVisible: boolean;
+	defaultOptions: Record<string, string>;
 };
 
 // Reads the live declarative settings tab (via app.setting.pluginTabs, which is
@@ -33,7 +34,7 @@ type SettingsSnapshot = {
 const SETTINGS_SNAPSHOT = `
 	(() => {
 		const tab = app.setting.pluginTabs.find((t) => t.id === ${JSON.stringify(PLUGIN_ID)});
-		if (!tab) return { found: false, headings: [], migrationVisible: false };
+		if (!tab) return { found: false, headings: [], migrationVisible: false, defaultOptions: {} };
 		const definitions = tab.getSettingDefinitions();
 		const groupVisible = (group) =>
 			typeof group.visible === "function"
@@ -42,10 +43,13 @@ const SETTINGS_SNAPSHOT = `
 		const migration = definitions.find(
 			(group) => group.heading === "Migrate credentials",
 		);
+		const accounts = definitions.find((group) => group.heading === "X accounts");
+		const defaultAccount = accounts?.items?.find((item) => item.name === "Default account");
 		return {
 			found: true,
 			headings: definitions.map((group) => group.heading),
 			migrationVisible: migration ? groupVisible(migration) : false,
+			defaultOptions: defaultAccount?.control?.options ?? {},
 		};
 	})()
 `;
@@ -58,7 +62,7 @@ describe("NoteTweet settings tab", () => {
 			await obsidian.dev.evalJson<SettingsSnapshot>(SETTINGS_SNAPSHOT);
 
 		expect(snapshot.found).toBe(true);
-		expect(snapshot.headings).toContain("X API credentials");
+		expect(snapshot.headings).toContain("X accounts");
 		expect(snapshot.headings).toContain("Posting");
 		expect(snapshot.headings).toContain("Scheduling");
 		// The migration group is always part of the definitions; with no legacy
@@ -66,6 +70,31 @@ describe("NoteTweet settings tab", () => {
 		// renders. This distinguishes "present but hidden" from "absent".
 		expect(snapshot.headings).toContain("Migrate credentials");
 		expect(snapshot.migrationVisible).toBe(false);
+		expect(snapshot.defaultOptions).toEqual({});
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	});
+
+	test("renders named account groups and the configured default choices", async () => {
+		const { obsidian, plugin } = getContext();
+		await plugin.updateDataAndReload(
+			() => ({
+				accounts: [
+					{ id: "personal", name: "Personal" },
+					{ id: "work", name: "Work" },
+				],
+				defaultAccountId: "work",
+				postTweetTag: "",
+				autoSplitTweets: true,
+				scheduling: { enabled: false, url: "" },
+			}),
+			RELOAD_OPTIONS,
+		);
+
+		const snapshot =
+			await obsidian.dev.evalJson<SettingsSnapshot>(SETTINGS_SNAPSHOT);
+		expect(snapshot.headings).toContain("Personal");
+		expect(snapshot.headings).toContain("Work");
+		expect(snapshot.defaultOptions).toEqual({ personal: "Personal", work: "Work" });
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
@@ -103,5 +132,88 @@ describe("NoteTweet settings tab", () => {
 		const snapshot =
 			await obsidian.dev.evalJson<SettingsSnapshot>(SETTINGS_SNAPSHOT);
 		expect(snapshot.migrationVisible).toBe(true);
+	});
+
+	test("migrates the four fixed secrets into one named account and clears the old keys", async () => {
+		const { obsidian, plugin } = getContext();
+		const oldIds = {
+			apiKey: "notetweet-api-key",
+			apiSecret: "notetweet-api-secret",
+			accessToken: "notetweet-access-token",
+			accessTokenSecret: "notetweet-access-token-secret",
+		};
+		const newIds = Object.fromEntries(
+			Object.entries({
+				apiKey: "api-key",
+				apiSecret: "api-secret",
+				accessToken: "access-token",
+				accessTokenSecret: "access-token-secret",
+			}).map(([field, suffix]) => [
+				field,
+				`notetweet-account-migrated-account-${suffix}`,
+			]),
+		);
+		const values = {
+			apiKey: "migration-ak",
+			apiSecret: "migration-as",
+			accessToken: "migration-at",
+			accessTokenSecret: "migration-ats",
+		};
+
+		try {
+			await obsidian.dev.evalJson<boolean>(
+				`(() => {
+					const ids = ${JSON.stringify(oldIds)};
+					const values = ${JSON.stringify(values)};
+					for (const key of Object.keys(ids)) app.secretStorage.setSecret(ids[key], values[key]);
+					return true;
+				})()`,
+			);
+			await plugin.updateDataAndReload(
+				() => ({
+					accounts: [],
+					defaultAccountId: "",
+					postTweetTag: "",
+					autoSplitTweets: true,
+					scheduling: { enabled: false, url: "" },
+				}),
+				RELOAD_OPTIONS,
+			);
+
+			const result = await obsidian.dev.evalJson<{
+				accounts: { id: string; name: string }[];
+				defaultAccountId: string;
+				oldValues: Record<string, string | null>;
+				newValues: Record<string, string | null>;
+			}>(
+				`(() => {
+					const plugin = app.plugins.plugins.${PLUGIN_ID};
+					const oldIds = ${JSON.stringify(oldIds)};
+					const newIds = ${JSON.stringify(newIds)};
+					return {
+						accounts: plugin.settings.accounts,
+						defaultAccountId: plugin.settings.defaultAccountId,
+						oldValues: Object.fromEntries(Object.entries(oldIds).map(([key, id]) => [key, app.secretStorage.getSecret(id)])),
+						newValues: Object.fromEntries(Object.entries(newIds).map(([key, id]) => [key, app.secretStorage.getSecret(id)])),
+					};
+				})()`,
+			);
+
+			expect(result.accounts).toEqual([
+				{ id: "migrated-account", name: "Default" },
+			]);
+			expect(result.defaultAccountId).toBe("migrated-account");
+			expect(result.newValues).toEqual(values);
+			expect(Object.values(result.oldValues).every((value) => value === "")).toBe(
+				true,
+			);
+		} finally {
+			await obsidian.dev.evalJson<boolean>(
+				`(() => {
+					for (const id of [...Object.values(${JSON.stringify(oldIds)}), ...Object.values(${JSON.stringify(newIds)})]) app.secretStorage.setSecret(id, "");
+					return true;
+				})()`,
+			);
+		}
 	});
 });


### PR DESCRIPTION
Add named X accounts to NoteTweet and route every direct posting path through one explicit account.

Account names, stable IDs, and the quick-post default live in plugin settings. Each account's API key, API secret, access token, and access token secret live only in deterministic Obsidian Secret Storage entries. This follows Obsidian's name-based Secret Storage model and X's OAuth 1.0a model, where the user access token pair determines the posting identity.

The composer starts on the configured default account and lets the user choose another account per post. `Post selection as tweet` and `Post file as thread` use the configured default because they intentionally bypass the composer. Each direct action creates and verifies an account-scoped client, and the post/delete flow retains that same client.

Migration is one-way and lossless. Existing four fixed Secret Storage values are copied into a deterministic `Default` account, the account metadata is saved, and only then are the fixed entries cleared. Older `data.json` and Secure Mode migrations now write directly into the same account model, so there is no fallback credential channel.

Scheduling remains intentionally independent. The self-hosted scheduler owns its own X credentials and posting identity, so a composer account selection affects immediate posting only. The composer and documentation now state this explicitly, and scheduled payloads carry no NoteTweet account ID.

Local validation:

- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` - 62 passed
- `pnpm run typecheck:e2e`
- `git diff --check`
- full isolated Obsidian 1.13.0 E2E suite - 11 passed, including fixed-secret migration, named settings groups, composer selection, selected-account posting, scheduler identity copy, and quick-post defaulting
- visual inspection in the isolated worktree instance confirmed the account picker and scheduler identity note preserve the composer hierarchy

Migration impact: existing fixed Secret Storage credentials migrate automatically on first load. Legacy `data.json` credentials retain the existing explicit migration prompt and land in the same named-account model.

Fixes #16
