### PR TITLE
fix: bundle punycode for mobile URL weighting

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,33 +1,8 @@
-import { builtinModules } from "node:module";
 import esbuild from "esbuild";
+import { createBuildOptions } from "./esbuild.options.mjs";
 
 const isProduction = process.argv.includes("production");
-
-const external = [
-  "obsidian",
-  "electron",
-  "@codemirror/*",
-  "@lezer/*",
-  ...builtinModules,
-  ...builtinModules.map((m) => `node:${m}`),
-];
-
-const options = {
-  entryPoints: ["src/main.ts"],
-  bundle: true,
-  outfile: "main.js",
-  format: "cjs",
-  platform: "browser",
-  target: "es2020",
-  sourcemap: isProduction ? false : "inline",
-  treeShaking: true,
-  external,
-  logLevel: "info",
-  define: {
-    "process.env.NODE_ENV": JSON.stringify(isProduction ? "production" : "development"),
-  },
-  plugins: [],
-};
+const options = createBuildOptions({ production: isProduction });
 
 if (isProduction) {
   await esbuild.build(options);

--- a/esbuild.options.mjs
+++ b/esbuild.options.mjs
@@ -1,0 +1,37 @@
+import { builtinModules } from "node:module";
+
+// twitter-text declares the browser-safe punycode package it imports. Do not
+// externalize that bare specifier as Node's deprecated builtin: mobile Obsidian
+// has no Node runtime, so esbuild must resolve and inline the package instead.
+const browserBundledModules = new Set(["punycode"]);
+const externalBuiltins = builtinModules.filter(
+  (module) => !browserBundledModules.has(module),
+);
+
+export function createBuildOptions({ production = false } = {}) {
+  return {
+    entryPoints: ["src/main.ts"],
+    bundle: true,
+    outfile: "main.js",
+    format: "cjs",
+    platform: "browser",
+    target: "es2020",
+    sourcemap: production ? false : "inline",
+    treeShaking: true,
+    external: [
+      "obsidian",
+      "electron",
+      "@codemirror/*",
+      "@lezer/*",
+      ...externalBuiltins,
+      ...externalBuiltins.map((module) => `node:${module}`),
+    ],
+    logLevel: "info",
+    define: {
+      "process.env.NODE_ENV": JSON.stringify(
+        production ? "production" : "development",
+      ),
+    },
+    plugins: [],
+  };
+}

--- a/tests/bundle-compatibility.test.ts
+++ b/tests/bundle-compatibility.test.ts
@@ -1,0 +1,34 @@
+import { builtinModules } from "node:module";
+import esbuild from "esbuild";
+import { describe, expect, it } from "vitest";
+import { createBuildOptions } from "../esbuild.options.mjs";
+
+describe("production bundle compatibility", () => {
+	it("bundles twitter-text's browser punycode implementation", async () => {
+		const result = await esbuild.build({
+			...createBuildOptions({ production: true }),
+			metafile: true,
+			write: false,
+			logLevel: "silent",
+		});
+		const bundle = result.outputFiles.find((file) => file.path.endsWith("main.js"));
+		expect(bundle).toBeDefined();
+
+		const code = bundle?.text ?? "";
+		const requires = [...code.matchAll(/\brequire\(["']([^"']+)["']\)/g)].map(
+			(match) => match[1],
+		);
+		const nodeBuiltins = new Set([
+			...builtinModules,
+			...builtinModules.map((module) => `node:${module}`),
+		]);
+
+		expect(requires).not.toContain("punycode");
+		expect(requires.filter((specifier) => nodeBuiltins.has(specifier))).toEqual([]);
+		expect(
+			Object.keys(result.metafile.inputs).some((path) =>
+				path.includes("/punycode@1.4.1/node_modules/punycode/punycode.js"),
+			),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
Bundle twitter-text's declared `punycode@1.4.1` implementation into NoteTweet's browser artifact so URL weighting works in mobile Obsidian without a Node runtime.

## Android blocker

Exact merged master `50dd0462345dfed1610f643c749af862d3d326d4` built a 322,550-byte `main.js` with SHA-256 `865e03d65591345e6b8806bbbd5807da877fc0be3677ef141333b403fc632360`. On Android 14, Obsidian 1.12.7, and Chrome WebView 113, the plugin loaded but entering any URL in the composer threw:

```text
TypeError: Cannot read properties of undefined (reading 'toASCII')
    at Object.toAscii
    at isValidUrl
    at extractUrlsWithIndices
    at analyzeTweetText
```

The production bundle contained `require("punycode")` because the build externalized every Node builtin. Mobile Obsidian cannot provide that builtin.

## Dependency and bundle design

The build now excludes only the bare `punycode` specifier from Node externalization. Existing `platform: "browser"` resolution therefore follows twitter-text's own dependency edge and inlines its pinned `punycode@1.4.1` package in the same analyzer path.

There is no runtime fallback, platform condition, shim, duplicate URL analyzer, dependency update, or lockfile change. The fixed production bundle has one external require: `obsidian`.

The new regression builds the real production options in memory and verifies that:

- no bare `require("punycode")` remains
- no Node builtin remains external
- the pinned browser-safe punycode implementation is present in the bundle graph

## Validation

Exact head `a2f0d819e543f17eb386fc6e9e9882846da77614` produced a 331,637-byte `main.js` with SHA-256 `66ecbd92d632fa712924cab8986f89da784ac89f7151111efe01dcb5a58f5495`. OMD verified the deployed Android file byte-for-byte.

Both the native-Intl run and a second run with `Intl.Segmenter` forcibly absent passed with exit code 0:

- `Promise.withResolvers` remained absent
- URL at weighted limit: count `0`, post enabled
- URL over limit: count `-1`, post blocked
- 141 CJK characters: count `-2`, post blocked
- 140 family emoji graphemes: count `0`, post enabled
- 280 combining-mark graphemes: count `0`, post enabled
- Personal and Project account options rendered; configured Project default selected; changing to Personal preserved weighted analysis
- line-oriented `THREAD START` / `THREAD END` selection parsed into two composer posts
- `core_smoke` passed and both focused probes captured zero JavaScript errors
- relevant logs contained no NoteTweet or WebView exception

Local and desktop validation:

- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` - 85 tests passed
- `pnpm run typecheck:e2e`
- full isolated Obsidian E2E - 14 tests passed
- isolated `dev:errors` - no errors captured
- `pnpm audit --prod --audit-level high` - no known vulnerabilities

There is no settings, credentials, data migration, or X API behavior change.

Fixes #54
