### PR TITLE
fix: bound account secret identifiers

### DIFF
--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -17,6 +17,22 @@ export const SECRET_IDS = {
 
 export type SecretId = string;
 
+const SECRET_ID_MAX_LENGTH = 64;
+const ACCOUNT_SECRET_PREFIX = "notetweet-account";
+
+const ACCOUNT_SECRET_SUFFIX = {
+	apiKey: "api-key",
+	apiSecret: "api-secret",
+	accessToken: "access-token",
+	accessTokenSecret: "access-token-secret",
+} as const satisfies Record<keyof TwitterCredentials, string>;
+
+export const MAX_ACCOUNT_ID_LENGTH =
+	SECRET_ID_MAX_LENGTH -
+	ACCOUNT_SECRET_PREFIX.length -
+	2 -
+	Math.max(...Object.values(ACCOUNT_SECRET_SUFFIX).map(({ length }) => length));
+
 export interface TwitterCredentials {
 	apiKey: string;
 	apiSecret: string;
@@ -46,12 +62,6 @@ export function setSecret(app: App, id: SecretId, value: string): void {
 	app.secretStorage?.setSecret(id, value);
 }
 
-const ACCOUNT_SECRET_SUFFIX = {
-	apiKey: "api-key",
-	apiSecret: "api-secret",
-	accessToken: "access-token",
-	accessTokenSecret: "access-token-secret",
-} as const satisfies Record<keyof TwitterCredentials, string>;
 const TWITTER_CREDENTIAL_FIELDS = Object.keys(
 	ACCOUNT_SECRET_SUFFIX,
 ) as (keyof TwitterCredentials)[];
@@ -60,7 +70,7 @@ export function accountSecretId(
 	accountId: string,
 	field: keyof TwitterCredentials,
 ): string {
-	return `notetweet-account-${accountId}-${ACCOUNT_SECRET_SUFFIX[field]}`;
+	return `${ACCOUNT_SECRET_PREFIX}-${accountId}-${ACCOUNT_SECRET_SUFFIX[field]}`;
 }
 
 export function getAccountCredentials(

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -1,8 +1,36 @@
 import {
+	createAccount,
 	DEFAULT_SETTINGS,
 	normalizeAccountSettings,
 	type NoteTweetSettings,
 } from "./settings";
+import {
+	accountSecretId,
+	MAX_ACCOUNT_ID_LENGTH,
+	type TwitterCredentials,
+} from "./secrets";
+
+const CREDENTIAL_FIELDS: (keyof TwitterCredentials)[] = [
+	"apiKey",
+	"apiSecret",
+	"accessToken",
+	"accessTokenSecret",
+];
+
+describe("createAccount", () => {
+	it("generates an opaque id that keeps every SecretStorage key within 64 characters", () => {
+		const account = createAccount(" Personal ");
+
+		expect(account).toEqual({
+			id: expect.stringMatching(/^[a-f0-9]{24}$/),
+			name: "Personal",
+		});
+		expect(account.id).toHaveLength(24);
+		for (const field of CREDENTIAL_FIELDS) {
+			expect(accountSecretId(account.id, field).length).toBeLessThanOrEqual(64);
+		}
+	});
+});
 
 describe("normalizeAccountSettings", () => {
 	it("preserves valid account metadata and its default", () => {
@@ -31,6 +59,7 @@ describe("normalizeAccountSettings", () => {
 				{ id: "personal", name: "Personal" },
 				{ id: "personal", name: "Duplicate" },
 				{ id: "../unsafe", name: "Unsafe" },
+				{ id: "a".repeat(MAX_ACCOUNT_ID_LENGTH + 1), name: "Too long" },
 				{ id: "blank-name", name: "  " },
 			],
 			defaultAccountId: "missing",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,3 +1,5 @@
+import { MAX_ACCOUNT_ID_LENGTH } from "./secrets";
+
 export interface XAccount {
 	id: string;
 	name: string;
@@ -30,6 +32,7 @@ export const DEFAULT_SETTINGS: NoteTweetSettings = {
 };
 
 const ACCOUNT_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const ACCOUNT_ID_BYTES = 12;
 
 /** Keep persisted account metadata safe for use in SecretStorage identifiers. */
 export function normalizeAccountSettings(settings: NoteTweetSettings): void {
@@ -39,6 +42,7 @@ export function normalizeAccountSettings(settings: NoteTweetSettings): void {
 			if (
 				!account ||
 				typeof account.id !== "string" ||
+				account.id.length > MAX_ACCOUNT_ID_LENGTH ||
 				!ACCOUNT_ID.test(account.id) ||
 				typeof account.name !== "string" ||
 				account.name.trim() === "" ||
@@ -58,5 +62,9 @@ export function normalizeAccountSettings(settings: NoteTweetSettings): void {
 }
 
 export function createAccount(name: string): XAccount {
-	return { id: crypto.randomUUID(), name: name.trim() };
+	const bytes = crypto.getRandomValues(new Uint8Array(ACCOUNT_ID_BYTES));
+	const id = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+		"",
+	);
+	return { id, name: name.trim() };
 }


### PR DESCRIPTION
Generate account IDs as 96-bit lowercase hex values and derive the accepted account-ID bound from Obsidian's 64-character Secret Storage limit. Persisted account metadata beyond that bound is rejected before it can produce invalid secret keys.

Android exposed the failure: UUID account IDs produced credential keys of 62, 65, 67, and 74 characters, so only the first secret was stored and migration aborted. The final keys are 50, 53, 55, and 62 characters, and the full encrypted migration now stores all four decrypted credentials and removes the legacy fields.

Verification:
- pnpm run lint
- pnpm run build
- pnpm run test (86 tests)
- pnpm run typecheck:e2e
- pnpm run test:e2e (14 live Obsidian tests)
- Android 14 / Obsidian 1.12.7 via OMD: plugin loaded, core smoke passed, encrypted 1.2.7-era ciphertext migrated into all four Secret Storage entries, and legacy fields were removed

Release impact: fixes an unreleased multi-account regression before 0.7.0. No migration shim is needed because UUID account IDs have not shipped.

Fixes #56